### PR TITLE
add from_tensorflow impl, test, and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ What follows here is a list of implemented and planned features.
 ### Loaders
 - [x] `Loader` (utility class used to define a dataset)
 - [x] `from_pytorch` (load from a `torch.utils.data.Dataset`)
-- [ ] `from_tensorflow` (load from a `tf.data.Dataset`)
+- [x] `from_tensorflow` (load from a `tf.data.Dataset`)
 - [x] `from_folder_data` (load flat folder with data)
 - [x] `from_folder_class_data` (load nested folder with a folder for each class)
 - [x] `from_folder_dataset_class_data` (load nested folder with multiple datasets, each with a nested class folder structure )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
             "tensorflow",
             "torch",
             "torchvision",
+            "tensorflow_datasets",
         ],
         "docs": ["Sphinx", "recommonmark", "sphinx_rtd_theme", "sphinx-autoapi"],
         "build": ["setuptools", "wheel", "twine"],

--- a/src/datasetops/dataset.py
+++ b/src/datasetops/dataset.py
@@ -504,9 +504,9 @@ class Dataset(AbstractDataset):
         if type(first) == str:
             names.append(first)  # type: ignore
         else:
-            assert type(first) is list
+            assert hasattr(first, "__len__")
             assert type(first[0]) is str
-            names = first  # type: ignore
+            names = list(first)  # type: ignore
 
         names.extend(rest)
 

--- a/tests/datasetops/test_loaders.py
+++ b/tests/datasetops/test_loaders.py
@@ -107,3 +107,39 @@ def test_pytorch():
 
     # labels are the same
     assert torch_ds[0][1] == ds_torch[0][1] == 0
+
+
+@pytest.mark.slow
+def test_tfds():
+    import tensorflow as tf
+    import tensorflow_datasets as tfds
+
+    # basic tf.data.Dataset
+
+    tf_123 = tf.data.Dataset.from_tensor_slices([1, 2, 3])
+    ds_123 = loaders.from_tensorflow(tf_123)
+
+    for t, d in zip(list(tf_123), list(ds_123)):
+        assert t.numpy() == d[0]
+
+    # from TFDS
+    tf_mnist = tfds.load("mnist", split="test")
+
+    ds_mnist = loaders.from_tensorflow(tf_mnist)
+
+    mnist_item = next(iter(tf_mnist))
+    ds_mnist_item = ds_mnist[0]
+
+    assert np.array_equal(mnist_item["image"].numpy(), ds_mnist_item[0])
+    assert np.array_equal(mnist_item["label"].numpy(), ds_mnist_item[1])
+
+    # also works for 'as_supervised'
+    tf_mnist = tfds.load("mnist", split="test", as_supervised=True)
+
+    ds_mnist = loaders.from_tensorflow(tf_mnist)
+
+    mnist_item = next(iter(tf_mnist))
+    ds_mnist_item = ds_mnist[0]
+
+    assert np.array_equal(mnist_item[0].numpy(), ds_mnist_item[0])
+    assert np.array_equal(mnist_item[1].numpy(), ds_mnist_item[1])


### PR DESCRIPTION
Implemented from_tensorflow.
Thought we discussed to have a local memory, in which dataset items could be added as needed, this implementation simply creates a list from the tf.data.Dataset generator. The runtime cost was found to be pretty modest, and it lets us read the dataset length without needing an additional argument (nicer API)