### PR TITLE
Feature scalers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,11 @@ What follows here is a list of implemented and planned features.
 - [ ] `image_brightness` (modify brightness of PIL.Image.Image elements)
 - [ ] `image_contrast` (modify contrast of PIL.Image.Image elements)
 - [ ] `image_filter` (apply an image filter to PIL.Image.Image elements)
+- [x] `center` (modify each item according to dataset statistics)
+- [x] `standardize` (modify each item according to dataset statistics)
+- [x] `minmax` (scale data to reside within a range)
+- [x] `maxabs` (scale each feature by its maximum absolute value.)
 - [ ] `noise` (adds noise to the data)
-- [ ] `center` (modify each item according to dataset statistics)
-- [ ] `normalize` (modify each item according to dataset statistics)
-- [ ] `standardize` (modify each item according to dataset statistics)
-- [ ] `minmax` (scale data to reside within a range)
-- [ ] `maxabs` (scale each feature by its maximum absolute value.)
 - [ ] `randomly` (apply data transformations with some probability)
 
 ### Dataset combinations 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ What follows here is a list of implemented and planned features.
 - [ ] `center` (modify each item according to dataset statistics)
 - [ ] `normalize` (modify each item according to dataset statistics)
 - [ ] `standardize` (modify each item according to dataset statistics)
-- [ ] `whiten` (modify each item according to dataset statistics)
+- [ ] `minmax` (scale data to reside within a range)
+- [ ] `maxabs` (scale each feature by its maximum absolute value.)
 - [ ] `randomly` (apply data transformations with some probability)
 
 ### Dataset combinations 

--- a/sandbox.py
+++ b/sandbox.py
@@ -1,7 +1,0 @@
-def main():
-
-    def func(s):
-        return s
-
-    zeros, others = do.load_mnist().split_filter(func)
-    all([(s.lbl == 0) for s in zeros])

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     packages=find_packages("src"),
     package_dir={"": "src"},
-    install_requires=["numpy", "pillow", "pandas", "scipy"],
+    install_requires=["numpy", "pillow", "pandas", "scikit-learn"],
     extras_require={
         "tests": [
             "pytest",

--- a/src/datasetops/__init__.py
+++ b/src/datasetops/__init__.py
@@ -19,7 +19,6 @@ https://datasetops.readthedocs.io/en/latest/
 from .dataset import (
     Dataset,
     allow_unique,
-    custom,
     reshape,
     categorical,
     one_hot,

--- a/src/datasetops/__init__.py
+++ b/src/datasetops/__init__.py
@@ -1,7 +1,6 @@
 from .dataset import (
     Dataset,
     allow_unique,
-    custom,
     reshape,
     categorical,
     one_hot,

--- a/src/datasetops/dataset.py
+++ b/src/datasetops/dataset.py
@@ -1075,7 +1075,7 @@ def _tf_item_conversion(item: Any):
     if type(item) == dict:
         return {str(k): _tf_item_conversion(v) for k, v in item.items()}
 
-    if type(item) in [Image.Image]:
+    if issubclass(type(item), Image.Image):
         return np.array(item)
 
     return item

--- a/src/datasetops/dataset.py
+++ b/src/datasetops/dataset.py
@@ -1062,7 +1062,7 @@ def _tf_item_conversion(item: Any):
     if type(item) == dict:
         return {str(k): _tf_item_conversion(v) for k, v in item.items()}
 
-    if type(item) in [Image.Image]:
+    if issubclass(type(item), Image.Image):
         return np.array(item)
 
     return item

--- a/src/datasetops/dataset.py
+++ b/src/datasetops/dataset.py
@@ -1,5 +1,6 @@
 import random
 from datasetops.abstract import ItemGetter, AbstractDataset
+from datasetops.scaler import ElemStats
 from datasetops.types import *
 import datasetops.compose as compose
 import numpy as np
@@ -10,6 +11,7 @@ from inspect import signature
 from datasetops.abstract import AbstractDataset
 from pathlib import Path
 from typing import overload, TypeVar
+from datasetops import scaler
 
 
 ########## Local Helpers ####################
@@ -22,8 +24,7 @@ def _warn_no_args(skip=0):
         @functools.wraps(fn)
         def wrapped(*args, **kwargs):
             if len(args) + len(kwargs) <= skip:
-                warnings.warn("Too few args passed to {}".format(
-                    fn.__code__.co_name))
+                warnings.warn("Too few args passed to {}".format(fn.__code__.co_name))
             return fn(*args, **kwargs)
 
         return wrapped
@@ -46,12 +47,12 @@ def _raise_no_args(skip=0):
     return with_args
 
 
-def _dummy_arg_receiving(fn):
-    @functools.wraps(fn)
-    def wrapped(dummy, *args, **kwargs):
-        return fn(*args, **kwargs)
+# def _dummy_arg_receiving(fn):
+#     @functools.wraps(fn)
+#     def wrapped(dummy, *args, **kwargs):
+#         return fn(*args, **kwargs)
 
-    return wrapped
+#     return wrapped
 
 
 def _key_index(item_names: ItemNames, key: Key) -> int:
@@ -79,14 +80,14 @@ def _split_bulk_itemwise(
 
 def _combine_conditions(
     item_names: ItemNames,
-    shape: Shape,
+    shape: Sequence[Shape],
     predicates: Optional[
         Union[DataPredicate, Sequence[Optional[DataPredicate]]]
     ] = None,
     **kwpredicates: DataPredicate
 ) -> DataPredicate:
 
-    bulk, itemwise = _split_bulk_itemwise(predicates)
+    bulk, itemwise = _split_bulk_itemwise(predicates)  # type:ignore
 
     if len(itemwise) > len(shape):
         raise ValueError("Too many predicates given")
@@ -110,8 +111,7 @@ def _combine_conditions(
             bulk(x)
             and all([pred(x[i]) for i, pred in enumerate(preds)])
             and all(
-                [pred(x[_key_index(item_names, k)])
-                 for k, pred in kwpredicates.items()]
+                [pred(x[_key_index(item_names, k)]) for k, pred in kwpredicates.items()]
             )
         )
 
@@ -119,19 +119,17 @@ def _combine_conditions(
 
 
 def _optional_argument_indexed_transform(
-    shape: Shape,
+    shape: Union[Shape, Sequence[Shape]],
     ds_transform: Callable,
     transform_fn: DatasetTransformFnCreator,
-    args: Sequence[Any],
+    args: Sequence[Optional[Sequence[Any]]],
 ):
     if len(args) == 0:
-        raise ValueError(
-            "Unable to perform transform: No arguments arguments given")
+        warnings.warn("Skipping transform: No arguments arguments given")
     if len(shape) < len(args):
-        raise ValueError(
-            "Unable to perform transform: Too many arguments given")
+        raise ValueError("Unable to perform transform: Too many arguments given")
 
-    tfs = [transform_fn(a) if a else None for a in args]
+    tfs = [transform_fn(*a) if (a != None) else None for a in args]
     return ds_transform(tfs)
 
 
@@ -139,18 +137,33 @@ def _keywise(item_names: Dict[str, int], l: Sequence, d: Dict):
     keywise = {i: v for i, v in enumerate(l)}
     keywise.update({_key_index(item_names, k): v for k, v in d.items()})
     return keywise
-    # return dict(
-    #     {i: v for i, v in enumerate(l)},
-    #     **{_key_index(item_names, k): v for k, v in d.items()}
-    # )
 
 
 def _itemwise(item_names: Dict[str, int], l: Sequence, d: Dict):
     keywise = _keywise(item_names, l, d)
-    itemwise = [
-        (keywise[i] if i in keywise else None) for i in range(max(keywise.keys()) + 1)
-    ]
+    keywise = {k: v for k, v in keywise.items() if v != None}
+    if keywise:
+        itemwise = [
+            ([keywise[i]] if i in keywise else None)
+            for i in range(max(keywise.keys()) + 1)
+        ]
+    else:
+        itemwise = []
     return itemwise
+
+
+def _keyarg2list(
+    item_names, key_or_keys: Union[Key, Sequence[Key]], arg: Sequence[Any]
+) -> List[Optional[Sequence[Any]]]:
+    if type(key_or_keys) in (list, tuple):
+        idxs: List[int] = [
+            _key_index(item_names, k) for k in key_or_keys  # type:ignore
+        ]
+    else:
+        idxs: List[int] = [_key_index(item_names, key_or_keys)]  # type: ignore
+
+    args = [arg if i in idxs else None for i in range(max(idxs) + 1)]
+    return args
 
 
 ########## Dataset ####################
@@ -167,6 +180,7 @@ class Dataset(AbstractDataset):
         ids: Ids = None,
         item_transform_fn: ItemTransformFn = lambda x: x,
         item_names: Dict[str, int] = None,
+        stats: List[Optional[ElemStats]] = [],
     ):
         """Initialise.
 
@@ -180,8 +194,7 @@ class Dataset(AbstractDataset):
 
         if issubclass(type(downstream_getter), AbstractDataset):
             self.name = self._downstream_getter.name  # type: ignore
-            # type: ignore
-            self._ids = list(range(len(self._downstream_getter._ids)))
+            self._ids = list(range(len(self._downstream_getter._ids)))  # type: ignore
             self._item_names = getattr(downstream_getter, "_item_names", None)
         else:
             self.name = ""
@@ -196,6 +209,7 @@ class Dataset(AbstractDataset):
             self._ids: Ids = ids
 
         self._item_transform_fn = item_transform_fn
+        self._item_stats = stats
 
     def __len__(self):
         return len(self._ids)
@@ -203,8 +217,51 @@ class Dataset(AbstractDataset):
     def __getitem__(self, i: int) -> Tuple:
         return self._item_transform_fn(self._downstream_getter[self._ids[i]])
 
+    def item_stats(self, item_key: Key, axis=None) -> scaler.ElemStats:
+        """Compute the statistics (mean, std, min, max) for an item element
+        
+        Arguments:
+            item_key {Key} -- index of string identifyer for element on which the stats should be computed
+        
+        Keyword Arguments:
+            axis {[type]} -- the axis on which to accumulate statistics (default: {None})
+        
+        Raises:
+            TypeError: if statistics cannot be computed on the element type
+        
+        Returns:
+            scaler.ElemStats -- Named tuple with (mean, std, min, max, axis)
+        """
+        idx = _key_index(self._item_names, item_key)
+        elem = self.__getitem__(0)[idx]
+
+        if not type(elem) in [int, float, np.ndarray] or issubclass(
+            type(elem), Image.Image
+        ):
+            raise TypeError(
+                "Cannot compute statistics for element of type {}".format(type(elem))
+            )
+
+        if not axis:
+            axis = -1 if issubclass(type(elem), Image.Image) else 0
+
+        if len(self._item_stats) <= idx:
+            for _ in range(idx - len(self._item_stats) + 1):
+                self._item_stats.append(None)
+
+        if not self._item_stats[idx] or self._item_stats[idx].axis != axis:
+
+            def iterable():
+                for item in self:
+                    yield np.array(item[idx])
+
+            self._item_stats[idx] = scaler.fit(
+                iterable(), shape=np.array(elem).shape, axis=axis
+            )
+        return self._item_stats[idx]  # type: ignore
+
     @property
-    def shape(self) -> Sequence[int]:
+    def shape(self) -> Sequence[Shape]:
         """Get the shape of a dataset item.
 
         Returns:
@@ -328,8 +385,7 @@ class Dataset(AbstractDataset):
         condition = _combine_conditions(
             self._item_names, self.shape, predicates, **kwpredicates
         )
-        new_ids = list(filter(lambda i: condition(
-            self.__getitem__(i)), self._ids))
+        new_ids = list(filter(lambda i: condition(self.__getitem__(i)), self._ids))
         return Dataset(downstream_getter=self, ids=new_ids)
 
     @_raise_no_args(skip=1)
@@ -360,8 +416,7 @@ class Dataset(AbstractDataset):
                 nack.append(i)
 
         return tuple(
-            [Dataset(downstream_getter=self, ids=new_ids)
-             for new_ids in [ack, nack]]
+            [Dataset(downstream_getter=self, ids=new_ids) for new_ids in [ack, nack]]
         )
 
     def shuffle(self, seed: int = None):
@@ -422,8 +477,7 @@ class Dataset(AbstractDataset):
 
         # create datasets corresponding to each split
         return tuple(
-            [Dataset(downstream_getter=self, ids=new_ids,)
-             for new_ids in split_ids]
+            [Dataset(downstream_getter=self, ids=new_ids,) for new_ids in split_ids]
         )
 
     def take(self, num: int):
@@ -436,8 +490,7 @@ class Dataset(AbstractDataset):
             Dataset -- A dataset with only the first `num` elements
         """
         if num > len(self):
-            raise ValueError(
-                "Can't take more elements than are available in dataset")
+            raise ValueError("Can't take more elements than are available in dataset")
 
         new_ids = list(range(num))
         return Dataset(downstream_getter=self, ids=new_ids)
@@ -546,8 +599,7 @@ class Dataset(AbstractDataset):
     def transform(
         self,
         fns: Optional[
-            Union[ItemTransformFn,
-                  Sequence[Union[ItemTransformFn, DatasetTransformFn]]]
+            Union[ItemTransformFn, Sequence[Union[ItemTransformFn, DatasetTransformFn]]]
         ] = None,
         **kwfns: DatasetTransformFn
     ):
@@ -584,9 +636,8 @@ class Dataset(AbstractDataset):
             for f in funcs:
                 if f:
                     if len(signature(f).parameters) == 1:
-                        f = custom(f)  # type:ignore
-                    new_dataset = f(_key_index(
-                        self._item_names, k), new_dataset)
+                        f = _custom(f)
+                    new_dataset = f(_key_index(self._item_names, k), new_dataset)
 
         return new_dataset
 
@@ -606,8 +657,7 @@ class Dataset(AbstractDataset):
         """
         idx: int = _key_index(self._item_names, key)
         mapping_fn = mapping_fn or categorical_template(self, key)
-        args = [mapping_fn or True if i ==
-                idx else None for i in range(idx + 1)]
+        args = [[mapping_fn] or [] if i == idx else None for i in range(idx + 1)]
         return _optional_argument_indexed_transform(
             self.shape, self.transform, transform_fn=categorical, args=args
         )
@@ -635,12 +685,11 @@ class Dataset(AbstractDataset):
         enc_size = encoding_size or len(self.unique(key))
         mapping_fn = mapping_fn or categorical_template(self, key)
         idx: int = _key_index(self._item_names, key)
-        args = [enc_size if i == idx else None for i in range(idx + 1)]
+        args = [[enc_size] if i == idx else None for i in range(idx + 1)]
         return _optional_argument_indexed_transform(
             self.shape,
             self.transform,
-            transform_fn=functools.partial(
-                one_hot, mapping_fn=mapping_fn, dtype=dtype),
+            transform_fn=functools.partial(one_hot, mapping_fn=mapping_fn, dtype=dtype),
             args=args,
         )
 
@@ -663,20 +712,16 @@ class Dataset(AbstractDataset):
             for elem in self.__getitem__(0):
                 try:
                     _check_image_compatibility(elem)
-                    positional_flags.append(True)  # didn't raise error
+                    positional_flags.append([])  # didn't raise error
                 except:
-                    positional_flags.append(False)
+                    positional_flags.append(None)
 
-        if any(positional_flags):
+        if any([f != None and f != False for f in positional_flags]):
             return _optional_argument_indexed_transform(
-                self.shape,
-                self.transform,
-                transform_fn=_dummy_arg_receiving(image),
-                args=positional_flags,
+                self.shape, self.transform, transform_fn=image, args=positional_flags,  # type: ignore
             )
         else:
-            warnings.warn(
-                "Conversion to image skipped. No elements were compatible")
+            warnings.warn("Conversion to image skipped. No elements were compatible")
             return self
 
     # TODO: reconsider API
@@ -694,17 +739,14 @@ class Dataset(AbstractDataset):
             positional_flags = []
             for elem in self.__getitem__(0):
                 try:
-                    _check_numpy_compatibility(elem)
-                    positional_flags.append(True)  # didn't raise error
+                    _check_numpy_compatibility()(elem)
+                    positional_flags.append([])  # didn't raise error
                 except:
-                    positional_flags.append(False)
+                    positional_flags.append(None)
 
-        if any(positional_flags):
+        if any([f != None and f != False for f in positional_flags]):
             return _optional_argument_indexed_transform(
-                self.shape,
-                self.transform,
-                transform_fn=_dummy_arg_receiving(numpy),
-                args=positional_flags,
+                self.shape, self.transform, transform_fn=numpy, args=positional_flags,  # type: ignore
             )
         else:
             warnings.warn(
@@ -733,9 +775,6 @@ class Dataset(AbstractDataset):
             args=_itemwise(self._item_names, new_shapes, kwshapes),
         )
 
-    # def scale(self, scaler):
-    #     pass
-
     # def add_noise(self, noise):
     #     pass
 
@@ -755,6 +794,114 @@ class Dataset(AbstractDataset):
     # def img_filter(self, filter_fn):
     #     pass
 
+    ########## Dataset scalers #########################
+
+    def standardize(self, key_or_keys: Union[Key, Sequence[Key]], axis=0):
+        """Standardize features by removing the mean and scaling to unit variance
+        
+        Arguments:
+            key_or_keys {Union[Key, Sequence[Key]]} -- The keys on which the Max Abs scaling should be performed
+        
+        Keyword Arguments:
+            axis {int} -- Axis on which to accumulate statistics (default: {0})
+        
+        Returns:
+            Dataset -- Transformed dataset
+        """
+        return _optional_argument_indexed_transform(
+            self.shape,
+            self.transform,
+            transform_fn=standardize,
+            args=_keyarg2list(self._item_names, key_or_keys, [axis]),
+        )
+
+    def center(self, key_or_keys: Union[Key, Sequence[Key]], axis=0):
+        """Centers features by removing the mean
+        
+        Arguments:
+            key_or_keys {Union[Key, Sequence[Key]]} -- The keys on which the Max Abs scaling should be performed
+        
+        Keyword Arguments:
+            axis {int} -- Axis on which to accumulate statistics (default: {0})
+        
+        Returns:
+            Dataset -- Transformed dataset
+        """
+        return _optional_argument_indexed_transform(
+            self.shape,
+            self.transform,
+            transform_fn=center,
+            args=_keyarg2list(self._item_names, key_or_keys, [axis]),
+        )
+
+    ## When people say normalize, they often mean either minmax or standardize.
+    ## This implementation follows the scikit-learn terminology
+    ## Not included in the library for now, because it is used very seldomly in practice
+    # def normalize(self, key_or_keys: Union[Key, Sequence[Key]], axis=0, norm="l2"):
+    #     """Normalize samples individually to unit norm.
+
+    #     Arguments:
+    #         key_or_keys {Union[Key, Sequence[Key]]} -- The keys on which the Max Abs scaling should be performed
+
+    #     Keyword Arguments:
+    #         axis {int} -- Axis on which to accumulate statistics (default: {0})
+
+    #     Keyword Arguments:
+    #         norm {str} -- "l1" or "l2"
+
+    #     Returns:
+    #         Dataset -- Transformed dataset
+    #     """
+    #     return _optional_argument_indexed_transform(
+    #         self.shape,
+    #         self.transform,
+    #         transform_fn=normalize,
+    #         args=_keyarg2list(self._item_names, key_or_keys, [axis]),
+    #     )
+
+    def minmax(
+        self, key_or_keys: Union[Key, Sequence[Key]], axis=0, feature_range=(0, 1)
+    ):
+        """Transform features by scaling each feature to a given range.
+        
+        Arguments:
+            key_or_keys {Union[Key, Sequence[Key]]} -- The keys on which the Max Abs scaling should be performed
+        
+        Keyword Arguments:
+            axis {int} -- Axis on which to accumulate statistics (default: {0})
+        
+        Keyword Arguments:
+            feature_range {Tuple[int, int]} -- Minimum and maximum bound to scale to
+        
+        Returns:
+            Dataset -- Transformed dataset
+        """
+        return _optional_argument_indexed_transform(
+            self.shape,
+            self.transform,
+            transform_fn=minmax,
+            args=_keyarg2list(self._item_names, key_or_keys, [axis, feature_range],),
+        )
+
+    def maxabs(self, key_or_keys: Union[Key, Sequence[Key]], axis=0):
+        """Scale each feature by its maximum absolute value.
+        
+        Arguments:
+            key_or_keys {Union[Key, Sequence[Key]]} -- The keys on which the Max Abs scaling should be performed
+        
+        Keyword Arguments:
+            axis {int} -- Axis on which to accumulate statistics (default: {0})
+        
+        Returns:
+            Dataset -- Transformed dataset
+        """
+        return _optional_argument_indexed_transform(
+            self.shape,
+            self.transform,
+            transform_fn=maxabs,
+            args=_keyarg2list(self._item_names, key_or_keys, [axis]),
+        )
+
     ########## Framework converters #########################
 
     def to_tensorflow(self):
@@ -767,24 +914,64 @@ class Dataset(AbstractDataset):
 ########## Handy decorators ####################
 
 
-def _dataset_element_transforming(fn: Callable, check: Callable = None):
-    """Applies the function to dataset item elements."""
-
-    # @functools.wraps(fn)
+def _make_dataset_element_transforming(
+    make_fn: Callable[[AbstractDataset, Optional[int]], Callable],
+    check: Callable = None,
+    maintain_stats=False,
+) -> DatasetTransformFn:
     def wrapped(idx: int, ds: AbstractDataset) -> AbstractDataset:
 
+        fn = make_fn(ds, idx)
+
         if check:
-            # grab an item and check its elements
-            for i, elem in enumerate(ds[0]):
-                if i == idx:
-                    check(elem)
+            check(ds[0][idx])
 
         def item_transform_fn(item: Sequence):
             return tuple(
                 [fn(elem) if i == idx else elem for i, elem in enumerate(item)]
             )
 
-        return Dataset(downstream_getter=ds, item_transform_fn=item_transform_fn,)
+        stats: List[Optional[ElemStats]] = []
+        if maintain_stats and hasattr(ds, "_item_stats"):
+            # maintain stats on other elements, and optionally on this one
+            stats = [
+                (s if i != idx else (s if maintain_stats else None))
+                for i, s in enumerate(ds._item_stats)  # type:ignore
+            ]
+
+        return Dataset(
+            downstream_getter=ds, item_transform_fn=item_transform_fn, stats=stats
+        )
+
+    return wrapped
+
+
+def _dataset_element_transforming(
+    fn: Callable, check: Callable = None, maintain_stats=False
+) -> DatasetTransformFn:
+    """Applies the function to dataset item elements."""
+
+    def wrapped(idx: int, ds: AbstractDataset) -> AbstractDataset:
+
+        if check:
+            check(ds[0][idx])
+
+        def item_transform_fn(item: Sequence):
+            return tuple(
+                [fn(elem) if i == idx else elem for i, elem in enumerate(item)]
+            )
+
+        stats: List[Optional[ElemStats]] = []
+        if maintain_stats and hasattr(ds, "_item_stats"):
+            # maintain stats on other elements, and optionally on this one
+            stats = [
+                (s if i != idx else (s if maintain_stats else None))
+                for i, s in enumerate(ds._item_stats)  # type:ignore
+            ]
+
+        return Dataset(
+            downstream_getter=ds, item_transform_fn=item_transform_fn, stats=stats
+        )
 
     return wrapped
 
@@ -833,12 +1020,18 @@ def _check_image_compatibility(elem):
     convert2img(elem)
 
 
-def _check_numpy_compatibility(elem):
-    # skip simple datatypes such as int and float as well
-    if type(elem) in [dict, str, int, float]:
-        raise ValueError("Unable to convert element {} to numpy".format(elem))
-    # check if this raises an Exception
-    np.array(elem)
+def _check_numpy_compatibility(allow_scalars=False):
+    allowed = [dict, str]
+    if not allow_scalars:
+        allowed.extend([int, float])
+
+    def fn(elem):
+        if type(elem) in allowed:
+            raise ValueError("Unable to convert element {} to numpy".format(elem))
+        # check if this raises an Exception
+        np.array(elem)
+
+    return fn
 
 
 ########## Predicate implementations ####################
@@ -872,7 +1065,7 @@ def allow_unique(max_num_duplicates=1) -> Callable[[Any], bool]:
 ########## Transform implementations ####################
 
 
-def custom(
+def _custom(
     elem_transform_fn: Callable[[Any], Any], elem_check_fn: Callable[[Any], None] = None
 ) -> DatasetTransformFn:
     """Create a user defined transform.
@@ -990,12 +1183,14 @@ def one_hot(
 
 
 def numpy() -> DatasetTransformFn:
-    return _dataset_element_transforming(fn=np.array, check=_check_numpy_compatibility)
+    return _dataset_element_transforming(
+        fn=np.array, check=_check_numpy_compatibility(), maintain_stats=True
+    )
 
 
 def image() -> DatasetTransformFn:
     return _dataset_element_transforming(
-        fn=convert2img, check=_check_image_compatibility
+        fn=convert2img, check=_check_image_compatibility, maintain_stats=True
     )
 
 
@@ -1004,6 +1199,120 @@ def image_resize(new_size: Shape, resample=Image.NEAREST) -> DatasetTransformFn:
     return _dataset_element_transforming(
         fn=lambda x: convert2img(x).resize(size=new_size, resample=resample),
         check=_check_image_compatibility,
+    )
+
+
+########## Dataset scalers #########################
+
+
+def standardize(axis=0) -> DatasetTransformFn:
+    """Standardize features by removing the mean and scaling to unit variance
+    
+    Keyword Arguments:
+        axis {int} -- Axis on which to accumulate statistics (default: {0})
+    
+    Returns:
+        DatasetTransformFn -- Function to be passed to Datasets.transform
+    """
+
+    def make_fn(ds, idx) -> Callable:
+        return scaler.standardize(shape=ds.shape[idx], stats=ds.item_stats(idx, axis))
+
+    return _make_dataset_element_transforming(
+        make_fn=make_fn,
+        check=_check_numpy_compatibility(allow_scalars=True),
+        maintain_stats=True,
+    )
+
+
+def center(axis=0) -> DatasetTransformFn:
+    """Center features by removing the mean
+    
+    Keyword Arguments:
+        axis {int} -- Axis on which to accumulate statistics (default: {0})
+    
+    Returns:
+        DatasetTransformFn -- Function to be passed to Datasets.transform
+    """
+
+    def make_fn(ds, idx) -> Callable:
+        return scaler.center(shape=ds.shape[idx], stats=ds.item_stats(idx, axis))
+
+    return _make_dataset_element_transforming(
+        make_fn=make_fn,
+        check=_check_numpy_compatibility(allow_scalars=True),
+        maintain_stats=True,
+    )
+
+
+## When people say normalize, they often mean either minmax or standardize.
+## This implementation follows the scikit-learn terminology
+## Not included in the library for now, because it is used very seldomly in practice
+# def normalize(axis=0, norm="l2") -> DatasetTransformFn:
+#     """Normalize samples individually to unit norm.
+
+#     Keyword Arguments:
+#         axis {int} -- Axis on which to accumulate statistics (default: {0})
+
+#     Keyword Arguments:
+#         norm {str} -- "l1" or "l2"
+
+#     Returns:
+#         DatasetTransformFn -- Function to be passed to Datasets.transform
+#     """
+
+#     def make_fn(ds, idx) -> Callable:
+#         return scaler.normalize(shape=ds.shape[idx], axis=axis, norm=norm,)
+
+#     return _make_dataset_element_transforming(
+#         make_fn=make_fn, check=_check_numpy_compatibility(allow_scalars=True),
+#     )
+
+
+def minmax(axis=0, feature_range=(0, 1)) -> DatasetTransformFn:
+    """Transform features by scaling each feature to a given range.
+    
+    Keyword Arguments:
+        axis {int} -- Axis on which to accumulate statistics (default: {0})
+    
+    Keyword Arguments:
+        feature_range {Tuple[int, int]} -- Minimum and maximum bound to scale to
+    
+    Returns:
+        DatasetTransformFn -- Function to be passed to Datasets.transform
+    """
+
+    def make_fn(ds, idx) -> Callable:
+        return scaler.minmax(
+            shape=ds.shape[idx],
+            stats=ds.item_stats(idx, axis),
+            feature_range=feature_range,
+        )
+
+    return _make_dataset_element_transforming(
+        make_fn=make_fn,
+        check=_check_numpy_compatibility(allow_scalars=True),
+        maintain_stats=True,
+    )
+
+
+def maxabs(axis=0) -> DatasetTransformFn:
+    """Scale each feature by its maximum absolute value.
+    
+    Keyword Arguments:
+        axis {int} -- Axis on which to accumulate statistics (default: {0})
+    
+    Returns:
+        DatasetTransformFn -- Function to be passed to Datasets.transform
+    """
+
+    def make_fn(ds, idx) -> Callable:
+        return scaler.maxabs(shape=ds.shape[idx], stats=ds.item_stats(idx, axis))
+
+    return _make_dataset_element_transforming(
+        make_fn=make_fn,
+        check=_check_numpy_compatibility(allow_scalars=True),
+        maintain_stats=True,
     )
 
 
@@ -1071,8 +1380,7 @@ def _tf_item_conversion(item: Any):
 def to_tensorflow(dataset: Dataset):
     import tensorflow as tf  # type:ignore
 
-    ds = Dataset(downstream_getter=dataset,
-                 item_transform_fn=_tf_item_conversion)
+    ds = Dataset(downstream_getter=dataset, item_transform_fn=_tf_item_conversion)
     item = ds[0]
     return tf.data.Dataset.from_generator(
         generator=dataset.generator,

--- a/src/datasetops/scaler.py
+++ b/src/datasetops/scaler.py
@@ -1,4 +1,4 @@
-from sklearn.preprocessing import StandardScaler, MinMaxScaler
+from sklearn.preprocessing import StandardScaler, MinMaxScaler, MaxAbsScaler
 from sklearn.preprocessing._data import _handle_zeros_in_scale
 import numpy as np
 from datasetops.types import *
@@ -85,7 +85,13 @@ class Scaler:
         return self._make_transform(scalers)
 
     def maxabs(self) -> ScalerFn:
-        pass
+        scalers = [MaxAbsScaler() if s else None for s in self._scaling_info]
+        for s, mms in zip(scalers, self._minmax_scalers):
+            if s:
+                s.scale_ = np.max(
+                    np.array([np.abs(mms.data_min_), mms.data_max_]), axis=0
+                )
+        return self._make_transform(scalers)
 
     def _make_transform(self, scalers) -> ScalerFn:
         def fn(item: Sequence[Any]) -> Sequence[Any]:

--- a/src/datasetops/scaler.py
+++ b/src/datasetops/scaler.py
@@ -1,0 +1,106 @@
+from sklearn.preprocessing import StandardScaler, MinMaxScaler
+from sklearn.preprocessing._data import _handle_zeros_in_scale
+import numpy as np
+from datasetops.types import *
+from collections import namedtuple
+from copy import deepcopy
+
+ScalingInfo = namedtuple("ScalingInfo", "shape axis")
+ScalingInfo.__new__.__defaults__ = (None,) * len(ScalingInfo._fields)
+ScalerFn = Callable[[Sequence[Any]], Sequence[Any]]
+
+
+def _make_scaler_reshapes(data_shape: Sequence[int], axis: int = 0):
+    if not axis:
+        axis = 0
+    if not data_shape:
+        # assuming data is a scalar
+        return lambda x: np.array([[x]]), lambda x: x[0][0]
+
+    ishape = list(data_shape)
+    ishape[0], ishape[axis] = ishape[axis], ishape[0]
+
+    def reshape_to_scale(d):
+        return np.swapaxes(  # type:ignore
+            np.swapaxes(d, 0, axis).reshape((data_shape[axis], -1)),  # type:ignore
+            0,
+            1,
+        )
+
+    def reshape_from_scale(d):
+        return np.swapaxes(np.swapaxes(d, 0, 1).reshape(ishape), 0, axis)  # type:ignore
+
+    return reshape_to_scale, reshape_from_scale
+
+
+class Scaler:
+    def __init__(self, scaling_info: Sequence[Optional[ScalingInfo]]):
+        self._scaling_info = scaling_info
+        self._std_scalers = []
+        self._minmax_scalers = []
+        self._forward = []  # data reshapers to scaling
+        self._backward = []  # data reshapers from scaling
+
+        for si in scaling_info:
+            if si:
+                self._std_scalers.append(StandardScaler())
+                self._minmax_scalers.append(MinMaxScaler())
+                forward, backward = _make_scaler_reshapes(si.shape, si.axis)
+                self._forward.append(forward)
+                self._backward.append(backward)
+            else:
+                self._std_scalers.append(None)
+                self._minmax_scalers.append(None)
+                self._forward.append(None)
+                self._backward.append(None)
+
+    def fit(self, item: Sequence[Any]):
+        for i, x in enumerate(item):
+            if i < len(self._scaling_info) and self._scaling_info[i]:
+                reshaped = self._forward[i](x)
+                self._std_scalers[i].partial_fit(reshaped)
+                self._minmax_scalers[i].partial_fit(reshaped)
+
+    def center(self, item: Sequence[Any]):
+        pass
+
+    def standardize(self, item: Sequence[Any]):
+        return tuple(
+            [
+                self._backward[i](
+                    self._std_scalers[i].transform(self._forward[i](elem))
+                )
+                if (len(self._scaling_info) > i and self._scaling_info[i])
+                else elem
+                for i, elem in enumerate(item)
+            ]
+        )
+
+    def minmax(self, feature_range=(0, 1)) -> ScalerFn:
+        scalers = deepcopy(self._minmax_scalers)
+        for s in scalers:
+            if s and s.feature_range != feature_range:
+                # update feature scaling
+                s.feature_range = feature_range
+                s.scale_ = (
+                    s.feature_range[1] - s.feature_range[0]
+                ) / _handle_zeros_in_scale(s.data_range_)
+                s.min_ = feature_range[0] - s.data_min_ * s.scale_
+        return self._make_transform(scalers)
+
+    def maxabs(self):
+        pass
+
+    def _make_transform(self, scalers) -> ScalerFn:
+        def fn(item: Sequence[Any]) -> Sequence[Any]:
+            nonlocal scalers
+            return tuple(
+                [
+                    self._backward[i](scalers[i].transform(self._forward[i](elem)))
+                    if i < len(self._scaling_info) and self._scaling_info[i]
+                    else elem
+                    for i, elem in enumerate(item)
+                ]
+            )
+
+        return fn

--- a/src/datasetops/scaler.py
+++ b/src/datasetops/scaler.py
@@ -61,8 +61,12 @@ class Scaler:
                 self._std_scalers[i].partial_fit(reshaped)
                 self._minmax_scalers[i].partial_fit(reshaped)
 
-    def center(self, item: Sequence[Any]) -> ScalerFn:
-        pass
+    def center(self) -> ScalerFn:
+        scalers = deepcopy(self._std_scalers)
+        for s in scalers:
+            if s:
+                s.with_std = False
+        return self._make_transform(scalers)
 
     def standardize(self) -> ScalerFn:
         scalers = deepcopy(self._std_scalers)
@@ -78,7 +82,6 @@ class Scaler:
                     s.feature_range[1] - s.feature_range[0]
                 ) / _handle_zeros_in_scale(s.data_range_)
                 s.min_ = feature_range[0] - s.data_min_ * s.scale_
-
         return self._make_transform(scalers)
 
     def maxabs(self) -> ScalerFn:

--- a/src/datasetops/types.py
+++ b/src/datasetops/types.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Sequence, Union, Any, List, Tuple, Optional
+from typing import Callable, Dict, Sequence, Union, Any, List, Tuple, Optional, Iterable
 from datasetops.abstract import AbstractDataset
 from pathlib import Path
 

--- a/src/datasetops/types.py
+++ b/src/datasetops/types.py
@@ -1,6 +1,4 @@
-"""Defines type-hints used various placed in the code."""
-
-from typing import Callable, Dict, Sequence, Union, Any, List, Tuple, Optional
+from typing import Callable, Dict, Sequence, Union, Any, List, Tuple, Optional, Iterable
 from datasetops.abstract import AbstractDataset
 from pathlib import Path
 

--- a/tests/datasetops/test_datasets.py
+++ b/tests/datasetops/test_datasets.py
@@ -19,6 +19,12 @@ from testing_utils import ( # type:ignore
     DATASET_PATHS, DUMMY_NUMPY_DATA_SHAPE_1D, DUMMY_NUMPY_DATA_SHAPE_2D, DUMMY_NUMPY_DATA_SHAPE_3D
 )
 
+def test_generator():
+    ds = from_dummy_data()
+    gen = ds.generator()
+
+    for d in list(ds):
+        assert d == next(gen)
 
 def test_shuffle():
     seed = 42

--- a/tests/datasetops/test_datasets.py
+++ b/tests/datasetops/test_datasets.py
@@ -23,6 +23,12 @@ from testing_utils import (  # type:ignore
     DUMMY_NUMPY_DATA_SHAPE_3D,
 )
 
+def test_generator():
+    ds = from_dummy_data()
+    gen = ds.generator()
+
+    for d in list(ds):
+        assert d == next(gen)
 
 def test_shuffle():
     seed = 42

--- a/tests/datasetops/test_datasets.py
+++ b/tests/datasetops/test_datasets.py
@@ -1,23 +1,29 @@
-
+from typing import Sequence
 from datasetops.dataset import (
-    Dataset, 
-    image_resize, 
-    reshape, 
-    custom, 
-    allow_unique, 
-    one_hot, 
-    categorical, 
+    Dataset,
+    image_resize,
+    reshape,
+    _custom,
+    allow_unique,
+    one_hot,
+    categorical,
     categorical_template,
-    _DEFAULT_SHAPE
+    _DEFAULT_SHAPE,
 )
 import datasetops.loaders as loaders
 import pytest
 import numpy as np
 from PIL import Image
-from testing_utils import ( # type:ignore
-    get_test_dataset_path, from_dummy_data, from_dummy_numpy_data,
-    DATASET_PATHS, DUMMY_NUMPY_DATA_SHAPE_1D, DUMMY_NUMPY_DATA_SHAPE_2D, DUMMY_NUMPY_DATA_SHAPE_3D
+from testing_utils import (  # type:ignore
+    get_test_dataset_path,
+    from_dummy_data,
+    from_dummy_numpy_data,
+    DATASET_PATHS,
+    DUMMY_NUMPY_DATA_SHAPE_1D,
+    DUMMY_NUMPY_DATA_SHAPE_2D,
+    DUMMY_NUMPY_DATA_SHAPE_3D,
 )
+
 
 def test_generator():
     ds = from_dummy_data()
@@ -25,6 +31,7 @@ def test_generator():
 
     for d in list(ds):
         assert d == next(gen)
+
 
 def test_shuffle():
     seed = 42
@@ -34,10 +41,10 @@ def test_shuffle():
     found_items = [i for i in ds_shuffled]
 
     # same data
-    assert(set(expected_items) == set(found_items))
+    assert set(expected_items) == set(found_items)
 
     # different sequence
-    assert(expected_items != found_items)
+    assert expected_items != found_items
 
 
 def test_sample():
@@ -47,63 +54,63 @@ def test_sample():
     found_items = [i for i in ds_sampled]
 
     # check list uniqueness
-    assert(len(found_items) == len(set(found_items)))
+    assert len(found_items) == len(set(found_items))
 
     # check items
-    expected_items = [ (i,) for i in [10,1,0,4,9]]
-    assert(set(expected_items) == set(found_items))
+    expected_items = [(i,) for i in [10, 1, 0, 4, 9]]
+    assert set(expected_items) == set(found_items)
 
     # check that different seeds yield different results
-    ds_sampled2 = ds.sample(5, seed+1)
+    ds_sampled2 = ds.sample(5, seed + 1)
     found_items2 = [i for i in ds_sampled2]
-    assert(set(found_items2) != set(found_items))
+    assert set(found_items2) != set(found_items)
 
 
 def test_filter():
-    num_total=10
-    ds = from_dummy_data(num_total=num_total, with_label=True).named('data', 'label')
+    num_total = 10
+    ds = from_dummy_data(num_total=num_total, with_label=True).named("data", "label")
 
     # expected items
-    a = [ (x, 'a') for x in list(range(5))]
-    b = [ (x, 'b') for x in list(range(5,num_total))]
-    even_a = [x for x in a if x[0]%2==0]
-    odd_a  = [x for x in a if x[0]%2==1]
-    even_b = [x for x in b if x[0]%2==0]
-    odd_b  = [x for x in b if x[0]%2==1]
+    a = [(x, "a") for x in list(range(5))]
+    b = [(x, "b") for x in list(range(5, num_total))]
+    even_a = [x for x in a if x[0] % 2 == 0]
+    odd_a = [x for x in a if x[0] % 2 == 1]
+    even_b = [x for x in b if x[0] % 2 == 0]
+    odd_b = [x for x in b if x[0] % 2 == 1]
 
     # itemwise
-    ds_even = ds.filter([lambda x: x%2==0])
-    assert(list(ds_even) == even_a + even_b) 
+    ds_even = ds.filter([lambda x: x % 2 == 0])
+    assert list(ds_even) == even_a + even_b
 
-    ds_even_a = ds.filter([lambda x: x%2==0, lambda x: x=='a'])
-    assert(list(ds_even_a) == even_a) 
+    ds_even_a = ds.filter([lambda x: x % 2 == 0, lambda x: x == "a"])
+    assert list(ds_even_a) == even_a
 
     # by key
-    ds_b = ds.filter(label=lambda x:x=='b')
-    assert(list(ds_b) == b)
+    ds_b = ds.filter(label=lambda x: x == "b")
+    assert list(ds_b) == b
 
     # bulk
-    ds_odd_b = ds.filter(lambda x: x[0]%2==1 and x[1]=='b')
-    assert(list(ds_odd_b) == odd_b)
+    ds_odd_b = ds.filter(lambda x: x[0] % 2 == 1 and x[1] == "b")
+    assert list(ds_odd_b) == odd_b
 
     # mix
-    ds_even_b = ds.filter([lambda x: x%2==0], label=lambda x: x=='b')
-    assert(list(ds_even_b) == even_b)
+    ds_even_b = ds.filter([lambda x: x % 2 == 0], label=lambda x: x == "b")
+    assert list(ds_even_b) == even_b
 
     # sample_classwise
     ds_classwise = ds.filter(label=allow_unique(2))
-    assert(list(ds_classwise) == list(a[:2] + b[:2]))
+    assert list(ds_classwise) == list(a[:2] + b[:2])
 
     # error scenarios
     with pytest.warns(UserWarning):
-        ds_same = ds.filter() # no args
-        assert(list(ds) == list(ds_same))
+        ds_same = ds.filter()  # no args
+        assert list(ds) == list(ds_same)
 
     with pytest.raises(ValueError):
-        ds.filter([None, None, None]) # too many args
+        ds.filter([None, None, None])  # too many args
 
     with pytest.raises(KeyError):
-        ds.filter(badkey=lambda x:True) # key doesn't exist
+        ds.filter(badkey=lambda x: True)  # key doesn't exist
 
 
 # def test_filter_old():
@@ -120,10 +127,10 @@ def test_filter():
 
 #     # itemwise
 #     ds_even = ds.filter(itemwise=[lambda x: x%2==0])
-#     assert(list(ds_even) == even_a + even_b) 
+#     assert(list(ds_even) == even_a + even_b)
 
 #     ds_even_a = ds.filter(itemwise=[lambda x: x%2==0, lambda x: x=='a'])
-#     assert(list(ds_even_a) == even_a) 
+#     assert(list(ds_even_a) == even_a)
 
 #     # by key
 #     ds_b = ds.filter(label=lambda x:x=='b')
@@ -154,55 +161,59 @@ def test_filter():
 
 
 def test_split_filter():
-    num_total=10
-    ds = from_dummy_data(num_total=num_total, with_label=True).named('data', 'label')
+    num_total = 10
+    ds = from_dummy_data(num_total=num_total, with_label=True).named("data", "label")
 
     # expected items
-    a = [ (x, 'a') for x in list(range(5))]
-    b = [ (x, 'b') for x in list(range(5,num_total))]
-    even_a = [x for x in a if x[0]%2==0]
-    odd_a  = [x for x in a if x[0]%2==1]
-    even_b = [x for x in b if x[0]%2==0]
-    odd_b  = [x for x in b if x[0]%2==1]
+    a = [(x, "a") for x in list(range(5))]
+    b = [(x, "b") for x in list(range(5, num_total))]
+    even_a = [x for x in a if x[0] % 2 == 0]
+    odd_a = [x for x in a if x[0] % 2 == 1]
+    even_b = [x for x in b if x[0] % 2 == 0]
+    odd_b = [x for x in b if x[0] % 2 == 1]
 
     # itemwise
-    ds_even, ds_odd = ds.split_filter([lambda x: x%2==0])
-    assert(list(ds_even) == even_a + even_b) 
-    assert(list(ds_odd) == odd_a + odd_b) 
+    ds_even, ds_odd = ds.split_filter([lambda x: x % 2 == 0])
+    assert list(ds_even) == even_a + even_b
+    assert list(ds_odd) == odd_a + odd_b
 
-    ds_even_a, ds_not_even_a = ds.split_filter([lambda x: x%2==0, lambda x: x=='a'])
-    assert(list(ds_even_a) == even_a) 
-    assert(list(ds_not_even_a) == odd_a + b) 
+    ds_even_a, ds_not_even_a = ds.split_filter(
+        [lambda x: x % 2 == 0, lambda x: x == "a"]
+    )
+    assert list(ds_even_a) == even_a
+    assert list(ds_not_even_a) == odd_a + b
 
     # by key
-    ds_b, ds_a = ds.split_filter(label=lambda x:x=='b')
-    assert(list(ds_b) == b)
-    assert(list(ds_a) == a)
+    ds_b, ds_a = ds.split_filter(label=lambda x: x == "b")
+    assert list(ds_b) == b
+    assert list(ds_a) == a
 
     # bulk
-    ds_odd_b, ds_even_b = ds.split_filter(lambda x: x[0]%2==1 and x[1]=='b')
-    assert(list(ds_odd_b) == odd_b)
-    assert(list(ds_even_b) == a + even_b)
+    ds_odd_b, ds_even_b = ds.split_filter(lambda x: x[0] % 2 == 1 and x[1] == "b")
+    assert list(ds_odd_b) == odd_b
+    assert list(ds_even_b) == a + even_b
 
     # mix
-    ds_even_b, ds_not_even_b = ds.split_filter([lambda x: x%2==0], label=lambda x: x=='b')
-    assert(list(ds_even_b) == even_b)
-    assert(list(ds_not_even_b) == [x for x in list(ds) if not x in even_b ])
+    ds_even_b, ds_not_even_b = ds.split_filter(
+        [lambda x: x % 2 == 0], label=lambda x: x == "b"
+    )
+    assert list(ds_even_b) == even_b
+    assert list(ds_not_even_b) == [x for x in list(ds) if not x in even_b]
 
     # sample_classwise
     ds_classwise_2, ds_classwise_rest = ds.split_filter(label=allow_unique(2))
-    assert(list(ds_classwise_2) == list(a[:2] + b[:2]))
-    assert(list(ds_classwise_rest) == list(a[2:] + b[2:]))
+    assert list(ds_classwise_2) == list(a[:2] + b[:2])
+    assert list(ds_classwise_rest) == list(a[2:] + b[2:])
 
     # error scenarios
     with pytest.raises(ValueError):
-        ds_same = ds.split_filter() # no args
+        ds_same = ds.split_filter()  # no args
 
     with pytest.raises(ValueError):
-        ds.split_filter([None, None, None]) # too many args
+        ds.split_filter([None, None, None])  # too many args
 
     with pytest.raises(KeyError):
-        ds.split_filter(badkey=lambda x:True) # key doesn't exist
+        ds.split_filter(badkey=lambda x: True)  # key doesn't exist
 
 
 def test_split():
@@ -211,20 +222,20 @@ def test_split():
     ds1, ds2, ds3 = ds.split([0.6, 0.3, 0.1], seed=seed)
 
     # new sets are distinct
-    assert(set(ds1) != set(ds2))
-    assert(set(ds1) != set(ds3))
-    assert(set(ds2) != set(ds3))
+    assert set(ds1) != set(ds2)
+    assert set(ds1) != set(ds3)
+    assert set(ds2) != set(ds3)
 
     # no values are lost
-    assert(set(ds) == set(ds1).union(set(ds2),set(ds3)))
+    assert set(ds) == set(ds1).union(set(ds2), set(ds3))
 
     # repeat for wildcard
     ds1w, ds2w, ds3w = ds.split([0.6, -1, 0.1], seed=seed)
 
     # using wildcard produces same results
-    assert(set(ds1) == set(ds1w))
-    assert(set(ds2) == set(ds2w))
-    assert(set(ds3) == set(ds3w))
+    assert set(ds1) == set(ds1w)
+    assert set(ds2) == set(ds2w)
+    assert set(ds3) == set(ds3w)
 
 
 def test_repeat():
@@ -232,22 +243,22 @@ def test_repeat():
 
     # itemwise
     ds_item = ds.repeat(3)
-    ds_item_alt = ds.repeat(3, mode='itemwise')
+    ds_item_alt = ds.repeat(3, mode="itemwise")
 
-    assert(set(ds) == set(ds_item_alt))
-    assert(list(ds_item) == list(ds_item_alt))
+    assert set(ds) == set(ds_item_alt)
+    assert list(ds_item) == list(ds_item_alt)
 
     # whole
-    ds_whole = ds.repeat(2, mode='whole')
-    assert(set(ds) == set(ds_whole))
-    assert(list(ds) == list(ds_whole)[:len(ds)] == list(ds_whole)[len(ds):])
+    ds_whole = ds.repeat(2, mode="whole")
+    assert set(ds) == set(ds_whole)
+    assert list(ds) == list(ds_whole)[: len(ds)] == list(ds_whole)[len(ds) :]
 
 
 def test_take():
-    ds = from_dummy_data().transform(lambda x: 10*x)
+    ds = from_dummy_data().transform(lambda x: 10 * x)
 
     ds_5 = ds.take(5)
-    assert(list(ds)[:5] == list(ds_5))
+    assert list(ds)[:5] == list(ds_5)
 
     with pytest.raises(ValueError):
         ds.take(10000000)
@@ -261,11 +272,11 @@ def test_reorder():
     with pytest.warns(UserWarning):
         # no order given
         ds_ignored = ds.reorder()
-        assert(ds == ds_ignored)
+        assert ds == ds_ignored
 
     with pytest.raises(ValueError):
         # indexes out of range
-        ds_re = ds.reorder(3,4)
+        ds_re = ds.reorder(3, 4)
 
     with pytest.raises(KeyError):
         # a keys doesn't exist
@@ -274,103 +285,116 @@ def test_reorder():
     ## working scenarios
 
     # using indexes
-    ds_re = ds.reorder(1,0)
+    ds_re = ds.reorder(1, 0)
     for (ldata, llbl), (rlbl, rdata) in zip(list(ds), list(ds_re)):
-        assert(np.array_equal(ldata, rdata))
-        assert(llbl == rlbl)
+        assert np.array_equal(ldata, rdata)
+        assert llbl == rlbl
 
     # same results using keys
-    ds_re_key = ds.reorder("mylabel","mydata")
+    ds_re_key = ds.reorder("mylabel", "mydata")
     for (llbl, ldata), (rlbl, rdata) in zip(list(ds_re_key), list(ds_re)):
-        assert(np.array_equal(ldata, rdata))
-        assert(llbl == rlbl)
+        assert np.array_equal(ldata, rdata)
+        assert llbl == rlbl
 
     # same result using a mix
-    ds_re_mix = ds.reorder(1,"mydata")
+    ds_re_mix = ds.reorder(1, "mydata")
     for (llbl, ldata), (rlbl, rdata) in zip(list(ds_re_mix), list(ds_re)):
-        assert(np.array_equal(ldata, rdata))
-        assert(llbl == rlbl)
+        assert np.array_equal(ldata, rdata)
+        assert llbl == rlbl
 
     # we can even place the same element multiple times
-    ds_re_creative = ds.reorder(0,1,1,0)
-    for (ldata, llbl), (rdata1, rlbl1, rlbl2, rdata2 ) in zip(list(ds), list(ds_re_creative)):
-        assert(np.array_equal(ldata, rdata1))
-        assert(np.array_equal(ldata, rdata2))
-        assert(llbl == rlbl1 == rlbl2)
+    with pytest.warns(UserWarning):
+        # but discard item-names (gives a warning)
+        ds_re_creative = ds.reorder(0, 1, 1, 0)
+
+    for (ldata, llbl), (rdata1, rlbl1, rlbl2, rdata2) in zip(
+        list(ds), list(ds_re_creative)
+    ):
+        assert np.array_equal(ldata, rdata1)
+        assert np.array_equal(ldata, rdata2)
+        assert llbl == rlbl1 == rlbl2
 
     # shape updates accordingly
-    assert(ds_re_creative.shape == (DUMMY_NUMPY_DATA_SHAPE_1D, _DEFAULT_SHAPE, _DEFAULT_SHAPE, DUMMY_NUMPY_DATA_SHAPE_1D))
+    assert ds_re_creative.shape == (
+        DUMMY_NUMPY_DATA_SHAPE_1D,
+        _DEFAULT_SHAPE,
+        _DEFAULT_SHAPE,
+        DUMMY_NUMPY_DATA_SHAPE_1D,
+    )
 
     # error scenarios
     with pytest.warns(UserWarning):
-        ds.named('one','two').reorder(0,1,1) # key needs to be unique, but wouldn't be
+        ds.named("one", "two").reorder(
+            0, 1, 1
+        )  # key needs to be unique, but wouldn't be
 
 
 ########## Tests relating to stats #########################
 
+
 def test_counts():
-    num_total=11
-    ds = from_dummy_data(num_total=num_total, with_label=True).named('data', 'label')
+    num_total = 11
+    ds = from_dummy_data(num_total=num_total, with_label=True).named("data", "label")
 
-    counts = ds.counts('label') # name based
-    counts_alt = ds.counts(1) # index based
+    counts = ds.counts("label")  # name based
+    counts_alt = ds.counts(1)  # index based
 
-    expected_counts = [('a', 5), ('b', num_total-5)]
-    assert(counts == counts_alt == expected_counts)
+    expected_counts = [("a", 5), ("b", num_total - 5)]
+    assert counts == counts_alt == expected_counts
 
     with pytest.warns(UserWarning):
         counts_all = ds.counts()
         # count all if no args are given
-        assert(set(counts_all) == set([(x, 1) for x in ds]))
+        assert set(counts_all) == set([(x, 1) for x in ds])
 
 
 def test_unique():
-    ds = from_dummy_data(with_label=True).named('data', 'label')
+    ds = from_dummy_data(with_label=True).named("data", "label")
 
-    unique_labels = ds.unique('label')
-    assert(unique_labels == ['a','b'])
+    unique_labels = ds.unique("label")
+    assert unique_labels == ["a", "b"]
 
     with pytest.warns(UserWarning):
         unique_items = ds.unique()
-        assert(unique_items == list(ds))
+        assert unique_items == list(ds)
 
 
 def test_shape():
     def get_data(i):
-        return i,i
+        return i, i
 
     # no shape yet
     ds = loaders.Loader(get_data)
-    assert(ds.shape == _DEFAULT_SHAPE)
+    assert ds.shape == _DEFAULT_SHAPE
 
     # shape given
     ds.append(1)
-    assert(ds.shape == (_DEFAULT_SHAPE, _DEFAULT_SHAPE))
+    assert ds.shape == (_DEFAULT_SHAPE, _DEFAULT_SHAPE)
 
     # numpy data
     ds_np = from_dummy_numpy_data().reshape(DUMMY_NUMPY_DATA_SHAPE_2D)
-    assert( ds_np.shape == (DUMMY_NUMPY_DATA_SHAPE_2D,_DEFAULT_SHAPE) )
+    assert ds_np.shape == (DUMMY_NUMPY_DATA_SHAPE_2D, _DEFAULT_SHAPE)
 
     # changed to new size
-    IMG_SIZE = (6,6)
+    IMG_SIZE = (6, 6)
     ds_img = ds_np.image_resize(IMG_SIZE)
-    assert( ds_img.shape == (IMG_SIZE,_DEFAULT_SHAPE) )
+    assert ds_img.shape == (IMG_SIZE, _DEFAULT_SHAPE)
 
     # image with three channels
     DUMMY_NUMPY_DATA_SHAPE_3D
     ds_np3 = ds_np.reshape(DUMMY_NUMPY_DATA_SHAPE_3D)
-    assert( ds_np3.shape == (DUMMY_NUMPY_DATA_SHAPE_3D,_DEFAULT_SHAPE) )
+    assert ds_np3.shape == (DUMMY_NUMPY_DATA_SHAPE_3D, _DEFAULT_SHAPE)
 
     ds_img3 = ds_np3.image_resize(IMG_SIZE)
-    assert( ds_img3.shape == ((*IMG_SIZE,3),_DEFAULT_SHAPE) )
+    assert ds_img3.shape == ((*IMG_SIZE, 3), _DEFAULT_SHAPE)
 
 
 def test_item_naming():
     ds = from_dummy_numpy_data()
     items = [x for x in ds]
-    assert(ds.names == [])
+    assert ds.names == []
 
-    item_names = ['mydata', 'mylabel']
+    item_names = ["mydata", "mylabel"]
 
     # named transform syntax doesn't work without item_names
     with pytest.raises(Exception):
@@ -378,19 +402,19 @@ def test_item_naming():
 
     # passed one by one as arguments
     ds.named(*item_names)
-    assert(ds.names == item_names)
+    assert ds.names == item_names
 
     # passed in a list, overide previous
-    item_names2 = ['moddata', 'modlabel']
-    ds.named(item_names2) #type: ignore
-    assert(ds.names == item_names2)
+    item_names2 = ["moddata", "modlabel"]
+    ds.named(item_names2)  # type: ignore
+    assert ds.names == item_names2
 
     # test named transform syntax
     ds_trans = ds.transform(moddata=reshape(DUMMY_NUMPY_DATA_SHAPE_2D))
     items_trans = [x for x in ds_trans]
     for (old_data, _), (new_data, _) in zip(items, items_trans):
-        assert(set(old_data) == set(new_data.flatten()))
-        assert(old_data.shape != new_data.shape)
+        assert set(old_data) == set(new_data.flatten())
+        assert old_data.shape != new_data.shape
 
     # invalid name doesn't work
     with pytest.raises(Exception):
@@ -398,12 +422,16 @@ def test_item_naming():
 
 
 def test_categorical():
-    ds = from_dummy_data(with_label=True).reorder(0,1,1).named('data', 'label', 'label_duplicate')
+    ds = (
+        from_dummy_data(with_label=True)
+        .reorder(0, 1, 1)
+        .named("data", "label", "label_duplicate")
+    )
 
-    assert(ds.unique('label') == ['a','b'])
+    assert ds.unique("label") == ["a", "b"]
 
     ds_label = ds.categorical(1)
-    ds_label_alt = ds.categorical('label')
+    ds_label_alt = ds.categorical("label")
 
     # alternative syntaxes
     ds_label = ds.categorical(1)
@@ -414,38 +442,42 @@ def test_categorical():
     expected = [0, 1]
 
     for l, l1, l2, l3, e in zip(
-        ds_label.unique('label'), 
-        ds_label_alt1.unique('label'), 
-        ds_label_alt2.unique('label'), 
-        ds_label_alt3.unique('label'), 
-        expected
+        ds_label.unique("label"),
+        ds_label_alt1.unique("label"),
+        ds_label_alt2.unique("label"),
+        ds_label_alt3.unique("label"),
+        expected,
     ):
-        assert(np.array_equal(l,l1))
-        assert(np.array_equal(l,l2))
-        assert(np.array_equal(l,l3))
-        assert(np.array_equal(l,e)) #type:ignore
+        assert np.array_equal(l, l1)
+        assert np.array_equal(l, l2)
+        assert np.array_equal(l, l3)
+        assert np.array_equal(l, e)  # type:ignore
 
-    assert(list(ds_label) == [(d, 0 if l == 'a' else 1 ,l2) for d, l, l2 in ds])
+    assert list(ds_label) == [(d, 0 if l == "a" else 1, l2) for d, l, l2 in ds]
 
-    ds_label_userdef = ds.categorical('label', lambda x: 1 if x == 'a' else 0)
+    ds_label_userdef = ds.categorical("label", lambda x: 1 if x == "a" else 0)
 
-    assert(ds_label_userdef.unique('label') == [1, 0])
-    assert(list(ds_label_userdef) == [(d, 1 if l == 'a' else 0 ,l2) for d, l, l2 in ds])
+    assert ds_label_userdef.unique("label") == [1, 0]
+    assert list(ds_label_userdef) == [(d, 1 if l == "a" else 0, l2) for d, l, l2 in ds]
 
     # error scenarios
     with pytest.raises(TypeError):
-        ds.categorical() # we need to know what to label
+        ds.categorical()  # we need to know what to label
 
     with pytest.raises(IndexError):
-        ds.categorical(42) # wrong key
+        ds.categorical(42)  # wrong key
 
     with pytest.raises(KeyError):
-        ds.categorical("wrong") # wrong key
+        ds.categorical("wrong")  # wrong key
 
 
 def test_one_hot():
-    ds = from_dummy_data(with_label=True).reorder(0,1,1).named('data', 'label', 'label_duplicate')
-    assert(ds.unique('label') == ['a','b'])
+    ds = (
+        from_dummy_data(with_label=True)
+        .reorder(0, 1, 1)
+        .named("data", "label", "label_duplicate")
+    )
+    assert ds.unique("label") == ["a", "b"]
 
     # alternative syntaxes
     ds_oh = ds.one_hot(1, encoding_size=2)
@@ -453,92 +485,104 @@ def test_one_hot():
     ds_oh_alt2 = ds.transform(label=one_hot(encoding_size=2))
     ds_oh_alt3 = ds.transform([None, one_hot(encoding_size=2)])
 
-    ds_oh_auto = ds.one_hot("label") # automatically compute encoding size
+    ds_oh_auto = ds.one_hot("label")  # automatically compute encoding size
 
     expected = [np.array([True, False]), np.array([False, True])]
 
     for l, l1, l2, l3, la, e in zip(
-        ds_oh.unique('label'), 
-        ds_oh_alt1.unique('label'), 
-        ds_oh_alt2.unique('label'), 
-        ds_oh_alt3.unique('label'), 
-        ds_oh_auto.unique('label'),
-        expected
+        ds_oh.unique("label"),
+        ds_oh_alt1.unique("label"),
+        ds_oh_alt2.unique("label"),
+        ds_oh_alt3.unique("label"),
+        ds_oh_auto.unique("label"),
+        expected,
     ):
-        assert(np.array_equal(l,l1))
-        assert(np.array_equal(l,l2))
-        assert(np.array_equal(l,l3))
-        assert(np.array_equal(l,la))
-        assert(np.array_equal(l,e)) #type:ignore
+        assert np.array_equal(l, l1)
+        assert np.array_equal(l, l2)
+        assert np.array_equal(l, l3)
+        assert np.array_equal(l, la)
+        assert np.array_equal(l, e)  # type:ignore
 
     for x, l, l2 in ds_oh:
-        ind = 0 if l2 == 'a' else 1
-        assert(np.array_equal(l, expected[ind])) #type:ignore
+        ind = 0 if l2 == "a" else 1
+        assert np.array_equal(l, expected[ind])  # type:ignore
 
     # spiced up
-    ds_oh_userdef = ds.one_hot('label', encoding_size=3, mapping_fn=lambda x: 1 if x == 'a' else 0, dtype='int')
+    ds_oh_userdef = ds.one_hot(
+        "label", encoding_size=3, mapping_fn=lambda x: 1 if x == "a" else 0, dtype="int"
+    )
 
-    for l, e in zip(ds_oh_userdef.unique('label'), [np.array([0,1,0]), np.array([1,0,0])]):
-        assert(np.array_equal(l,e)) #type:ignore
+    for l, e in zip(
+        ds_oh_userdef.unique("label"), [np.array([0, 1, 0]), np.array([1, 0, 0])]
+    ):
+        assert np.array_equal(l, e)  # type:ignore
 
     # error scenarios
     with pytest.raises(TypeError):
-        ds.one_hot() # we need some arguments
+        ds.one_hot()  # we need some arguments
 
     with pytest.raises(IndexError):
-        ds.one_hot(42, encoding_size=2) # wrong key
+        ds.one_hot(42, encoding_size=2)  # wrong key
 
     with pytest.raises(IndexError):
-        list(ds.one_hot('label', encoding_size=1)) # encoding size too small -- found at runtime
+        list(
+            ds.one_hot("label", encoding_size=1)
+        )  # encoding size too small -- found at runtime
 
     with pytest.raises(KeyError):
-        ds.one_hot("wrong", encoding_size=2) # wrong key
+        ds.one_hot("wrong", encoding_size=2)  # wrong key
 
 
 def test_categorical_template():
-    ds1 = from_dummy_data(with_label=True).named("data","label")
+    ds1 = from_dummy_data(with_label=True).named("data", "label")
     ds2 = ds1.shuffle(42)
 
     # when using categorical encoding on multiple datasets that are used together, the encoding may turn out different
     # this is because the indexes are built up and mapped as they are loaded (the order matters)
-    assert set(ds1.transform(label=categorical())) != set(ds2.transform(label=categorical()))
+    assert set(ds1.transform(label=categorical())) != set(
+        ds2.transform(label=categorical())
+    )
 
     # we can use the categorical template to make matching encodings
     mapping_fn = categorical_template(ds1, "label")
-    assert set(ds1.transform(label=categorical(mapping_fn))) == set(ds2.transform(label=categorical(mapping_fn)))
+    assert set(ds1.transform(label=categorical(mapping_fn))) == set(
+        ds2.transform(label=categorical(mapping_fn))
+    )
 
     # this is done implicitely when using the class-member functions
     assert set(ds1.categorical("label")) == set(ds2.categorical("label"))
 
 
 def test_transform():
-    ds = from_dummy_numpy_data().named("data","label") 
+    ds = from_dummy_numpy_data().named("data", "label")
 
     # simple
-    ds_itemwise = ds.transform([lambda x: x/255.0])
-    ds_keywise = ds.transform(data=lambda x: x/255.0)
-    ds_build = ds.transform(lambda x: (x[0]/255.0, x[1])) 
-    
-    for (d, l), (di, li), (dk, lk), (db, lb) in zip(list(ds), list(ds_itemwise), list(ds_keywise), list(ds_build)):
-        assert(np.array_equal(d/255.0, di))
-        assert(np.array_equal(di, dk))
-        assert(np.array_equal(di, db))
-        assert(l == li == lk == lb)
+    ds_itemwise = ds.transform([lambda x: x / 255.0])
+    ds_keywise = ds.transform(data=lambda x: x / 255.0)
+    ds_build = ds.transform(lambda x: (x[0] / 255.0, x[1]))
+
+    for (d, l), (di, li), (dk, lk), (db, lb) in zip(
+        list(ds), list(ds_itemwise), list(ds_keywise), list(ds_build)
+    ):
+        assert np.array_equal(d / 255.0, di)
+        assert np.array_equal(di, dk)
+        assert np.array_equal(di, db)
+        assert l == li == lk == lb
 
     # complex
     ds_complex = ds.transform(
-        data=[reshape(DUMMY_NUMPY_DATA_SHAPE_2D), image_resize((10,10))],
-        label=one_hot(encoding_size=2)
+        data=[reshape(DUMMY_NUMPY_DATA_SHAPE_2D), image_resize((10, 10))],
+        label=one_hot(encoding_size=2),
     )
 
-    assert(ds_complex.shape == ((10,10),(2,)))
+    assert ds_complex.shape == ((10, 10), (2,))
 
     # error scenarios
     with pytest.warns(UserWarning):
         # no args
         ds.transform()
-    
-    with pytest.raises(ValueError): 
+
+    with pytest.raises(ValueError):
         # too many transforms given
         ds.transform([reshape(DUMMY_NUMPY_DATA_SHAPE_2D), None, None])
 
@@ -547,12 +591,12 @@ def test_transform():
 
 
 def test_reshape():
-    ds = from_dummy_numpy_data().named('data','label')
+    ds = from_dummy_numpy_data().named("data", "label")
     items = list(ds)
 
     s = ds.shape
-    assert(ds.shape == (DUMMY_NUMPY_DATA_SHAPE_1D, _DEFAULT_SHAPE) )
-    assert(ds[0][0].shape == DUMMY_NUMPY_DATA_SHAPE_1D)
+    assert ds.shape == (DUMMY_NUMPY_DATA_SHAPE_1D, _DEFAULT_SHAPE)
+    assert ds[0][0].shape == DUMMY_NUMPY_DATA_SHAPE_1D
 
     # reshape adding extra dim
     ds_r = ds.reshape(DUMMY_NUMPY_DATA_SHAPE_2D)
@@ -560,65 +604,68 @@ def test_reshape():
     items_r = list(ds_r)
     items_r_alt = list(ds_r_alt)
 
-    assert(ds_r.shape == ( DUMMY_NUMPY_DATA_SHAPE_2D, _DEFAULT_SHAPE) )
-    assert(ds_r[0][0].shape == DUMMY_NUMPY_DATA_SHAPE_2D)
+    assert ds_r.shape == (DUMMY_NUMPY_DATA_SHAPE_2D, _DEFAULT_SHAPE)
+    assert ds_r[0][0].shape == DUMMY_NUMPY_DATA_SHAPE_2D
 
-    for (old_data, l), (new_data, ln), (new_data_alt, lna) in zip(items, items_r, items_r_alt):
-        assert(set(old_data) == set(new_data.flatten()) == set(new_data_alt.flatten()))
-        assert(old_data.shape != new_data.shape == new_data_alt.shape)
-        assert(l == ln == lna)
+    for (old_data, l), (new_data, ln), (new_data_alt, lna) in zip(
+        items, items_r, items_r_alt
+    ):
+        assert set(old_data) == set(new_data.flatten()) == set(new_data_alt.flatten())
+        assert old_data.shape != new_data.shape == new_data_alt.shape
+        assert l == ln == lna
 
     # use wildcard
-    ds_wild = ds.reshape((-1,DUMMY_NUMPY_DATA_SHAPE_2D[1]))
+    ds_wild = ds.reshape((-1, DUMMY_NUMPY_DATA_SHAPE_2D[1]))
     items_wild = list(ds_wild)
     for (old_data, _), (new_data, _) in zip(items_r, items_wild):
-        assert(np.array_equal(old_data, new_data))
+        assert np.array_equal(old_data, new_data)
 
     # reshape back, alternative syntax
     ds_back = ds_r.reshape(DUMMY_NUMPY_DATA_SHAPE_1D, None)
     items_back = [x for x in ds_back]
 
     for (old_data, _), (new_data, _) in zip(items, items_back):
-        assert(np.array_equal(old_data, new_data))
+        assert np.array_equal(old_data, new_data)
 
     # yet another syntax
     ds_trans = ds.transform([reshape(DUMMY_NUMPY_DATA_SHAPE_2D)])
     items_trans = [x for x in ds_trans]
     for (old_data, _), (new_data, _) in zip(items_r, items_trans):
-        assert(np.array_equal(old_data, new_data))
+        assert np.array_equal(old_data, new_data)
 
     # doing nothing also works
-    ds_dummy = ds.reshape(None, None)
+    with pytest.warns(UserWarning):
+        ds_dummy = ds.reshape(None, None)
     items_dummy = [x for x in ds_dummy]
     for (old_data, _), (new_data, _) in zip(items, items_dummy):
-        assert(np.array_equal(old_data, new_data))
+        assert np.array_equal(old_data, new_data)
 
     # TODO test reshape on string data
     ds_str = loaders.from_folder_data(get_test_dataset_path(DATASET_PATHS.FOLDER_DATA))
 
     with pytest.raises(ValueError):
-        # string has no shape 
-        ds_str.reshape((1,2))
+        # string has no shape
+        ds_str.reshape((1, 2))
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         # No input
-        ds.reshape() 
+        ds.reshape()
 
     with pytest.raises(TypeError):
         # bad input
-        ds.reshape('whazzagh') 
-    
-    with pytest.raises(ValueError):
+        ds.reshape("whazzagh")
+
+    with pytest.warns(UserWarning):
         # Too many inputs
-        ds.reshape(None, None, None) 
+        ds.reshape(None, None, None)
 
     with pytest.raises(ValueError):
         # Dimensions don't match
-        ds.reshape((13,13)) 
-
+        ds.reshape((13, 13))
 
 
 ########## Tests relating to image data #########################
+
 
 def test_numpy_image_numpy_conversion():
     ds_1d = from_dummy_numpy_data()
@@ -626,16 +673,16 @@ def test_numpy_image_numpy_conversion():
 
     # Warns because no elements where converted
     with pytest.warns(None) as record:
-        ds2 = ds_1d.image() # skipped all because they could't be converted
+        ds2 = ds_1d.image()  # skipped all because they could't be converted
         ds3 = ds_1d.image(False, False)
-    assert(len(record) == 2) # warns on both
+    assert len(record) == 2  # warns on both
 
     # The two previous statements didn't create any changes
     items2 = [x for x in ds2]
     items3 = [x for x in ds3]
     for (one, _), (two, _), (three, _) in zip(items_1d, items2, items3):
-        assert(np.array_equal(one, two))
-        assert(np.array_equal(two, three))
+        assert np.array_equal(one, two)
+        assert np.array_equal(two, three)
 
     # Force conversion of first arg - doesn't work due to shape incompatibility
     with pytest.raises(Exception):
@@ -648,28 +695,25 @@ def test_numpy_image_numpy_conversion():
     # Succesful conversion should happen here
     with pytest.warns(None) as record:
         ds_img = ds_2d.image()
-    assert(len(record) == 0)
+    assert len(record) == 0
 
     items_img = [x for x in ds_img]
     for (one, lbl1), (two, lbl2) in zip(items_2d, items_img):
-        assert(type(one) == np.ndarray)
-        assert(type(two) == Image.Image)
-        assert(lbl1 == lbl2)
+        assert type(one) == np.ndarray
+        assert type(two) == Image.Image
+        assert lbl1 == lbl2
 
     # test the backward-conversion
     ds_np = ds_img.numpy()
     items_np = [x for x in ds_np]
     for (one, lbl1), (two, lbl2) in zip(items_2d, items_np):
-        assert(type(one) == type(two))
-        assert(np.array_equal(one, two))
-        assert(lbl1 == lbl2)
+        assert type(one) == type(two)
+        assert np.array_equal(one, two)
+        assert lbl1 == lbl2
 
     # well get a warning if it doens't convert any
     with pytest.warns(UserWarning):
         ds_img.numpy(False)
-
-
-    
 
 
 def test_string_image_conversion():
@@ -681,56 +725,57 @@ def test_string_image_conversion():
 
     for data in items_img:
         data = data[0]
-        assert(issubclass(type(data), Image.Image))
+        assert issubclass(type(data), Image.Image)
 
 
 def test_image_resize():
     ds = from_dummy_numpy_data().reshape(DUMMY_NUMPY_DATA_SHAPE_2D)
     for tpl in ds:
         data = tpl[0]
-        assert(data.shape == DUMMY_NUMPY_DATA_SHAPE_2D)
+        assert data.shape == DUMMY_NUMPY_DATA_SHAPE_2D
 
-    NEW_SIZE = (5,5)
+    NEW_SIZE = (5, 5)
 
     # works directly on numpy arrays (ints)
     ds_resized = ds.image_resize(NEW_SIZE)
     for tpl in ds_resized:
         data = tpl[0]
-        assert(data.size == NEW_SIZE)
-        assert(data.mode == 'L') # grayscale int
+        assert data.size == NEW_SIZE
+        assert data.mode == "L"  # grayscale int
 
     # also if they are floats
-    ds_resized_float = ds.transform([custom(np.float32)]).image_resize(NEW_SIZE)
+    ds_resized_float = ds.transform([_custom(np.float32)]).image_resize(NEW_SIZE)
     for tpl in ds_resized_float:
         data = tpl[0]
-        assert(data.size == NEW_SIZE)
-        assert(data.mode == 'F') # grayscale float
+        assert data.size == NEW_SIZE
+        assert data.mode == "F"  # grayscale float
 
     # works directly on strings
     ds_str = loaders.from_folder_data(get_test_dataset_path(DATASET_PATHS.FOLDER_DATA))
     ds_resized_from_str = ds_str.image_resize(NEW_SIZE)
     for tpl in ds_resized_from_str:
         data = tpl[0]
-        assert(data.size == NEW_SIZE)
+        assert data.size == NEW_SIZE
 
     # works on other images (scaling down)
     ds_resized_again = ds_resized.image_resize(DUMMY_NUMPY_DATA_SHAPE_2D)
     for tpl in ds_resized_again:
         data = tpl[0]
-        assert(data.size == DUMMY_NUMPY_DATA_SHAPE_2D)
+        assert data.size == DUMMY_NUMPY_DATA_SHAPE_2D
 
     # Test error scenarios
-    with pytest.raises(ValueError):
-        ds.image_resize() # No args
+    with pytest.warns(UserWarning):
+        ds.image_resize()  # No args
 
     with pytest.raises(ValueError):
-        ds.image_resize(NEW_SIZE, NEW_SIZE, NEW_SIZE) # Too many args
+        ds.image_resize(NEW_SIZE, NEW_SIZE, NEW_SIZE)  # Too many args
 
     with pytest.raises(AssertionError):
-        ds.image_resize((4,4,4)) # Invalid size
+        ds.image_resize((4, 4, 4))  # Invalid size
 
 
 ########## Framework converters #########################
+
 
 @pytest.mark.slow
 def test_to_tensorflow():
@@ -739,19 +784,22 @@ def test_to_tensorflow():
     tf_ds = ds.to_tensorflow().batch(2)
 
     # prep model
-    import tensorflow as tf #type:ignore     
+    import tensorflow as tf  # type:ignore
+
     tf.random.set_seed(42)
 
-    model = tf.keras.Sequential([
-        tf.keras.layers.Input(ds.shape[0]),
-        tf.keras.layers.Dense(10, activation='relu'),
-        tf.keras.layers.Dense(2, activation='softmax'),
-    ])
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input(ds.shape[0]),
+            tf.keras.layers.Dense(10, activation="relu"),
+            tf.keras.layers.Dense(2, activation="softmax"),
+        ]
+    )
 
     model.compile(
-        optimizer='adam',
+        optimizer="adam",
         loss=tf.keras.losses.CategoricalCrossentropy(),
-        metrics=['accuracy']
+        metrics=["accuracy"],
     )
 
     # model should be able to fit the data
@@ -759,8 +807,8 @@ def test_to_tensorflow():
     preds = model.predict(tf_ds)
     pred_labels = np.argmax(preds, axis=1)
 
-    expected_labels = np.array([v[0] for v in ds.reorder('label').categorical(0)])
-    assert sum(pred_labels == expected_labels) > len(ds)//2  #type:ignore
+    expected_labels = np.array([v[0] for v in ds.reorder("label").categorical(0)])
+    assert sum(pred_labels == expected_labels) > len(ds) // 2  # type:ignore
 
 
 @pytest.mark.slow
@@ -771,14 +819,58 @@ def test_to_pytorch():
 
     import torch
     from torch.utils.data import DataLoader
+
     loader = DataLoader(pt_ds, batch_size=2, shuffle=False)
-    
+
     elem = next(iter(loader))
 
     # data equals
-    assert(torch.all(torch.eq(elem[0][0], torch.Tensor(ds[0][0])))) #type:ignore
-    assert(torch.all(torch.eq(elem[0][1], torch.Tensor(ds[1][0])))) #type:ignore
+    assert torch.all(torch.eq(elem[0][0], torch.Tensor(ds[0][0])))  # type:ignore
+    assert torch.all(torch.eq(elem[0][1], torch.Tensor(ds[1][0])))  # type:ignore
 
     # labels equal
-    assert(torch.all(torch.eq(elem[1][0], torch.Tensor(ds[0][1])))) #type:ignore
-    assert(torch.all(torch.eq(elem[1][1], torch.Tensor(ds[1][1])))) #type:ignore
+    assert torch.all(torch.eq(elem[1][0], torch.Tensor(ds[0][1])))  # type:ignore
+    assert torch.all(torch.eq(elem[1][1], torch.Tensor(ds[1][1])))  # type:ignore
+
+
+def test_stats():
+    from sklearn.preprocessing import StandardScaler, MinMaxScaler
+
+    # numpy data
+    ds_np = from_dummy_numpy_data().reshape(DUMMY_NUMPY_DATA_SHAPE_3D)
+
+    std_scaler = StandardScaler()
+    mm_scaler = MinMaxScaler()
+
+    axis = 2
+
+    def _make_scaler_reshapes(data_shape: Sequence[int], axis: int = 0):
+
+        ishape = list(data_shape)
+        ishape[0], ishape[axis] = ishape[axis], ishape[0]
+
+        def reshape_to_scale(d):
+            return np.swapaxes(  # type:ignore
+                np.swapaxes(d, 0, axis).reshape((data_shape[axis], -1)),  # type:ignore
+                0,
+                1,
+            )
+
+        def reshape_from_scale(d):
+            return np.swapaxes(  # type:ignore
+                np.swapaxes(d, 0, 1).reshape(ishape), 0, axis  # type:ignore
+            )
+
+        return reshape_to_scale, reshape_from_scale
+
+    reshape_to_scale, reshape_from_scale = _make_scaler_reshapes(ds_np[0][0].shape, 2)
+
+    for d, l in ds_np:
+        old_shape = d.shape
+        # stats are accumulated along 2nd axis in sklearn preprocessing: reshape accordingly
+        dlist = np.swapaxes(  # type:ignore
+            np.swapaxes(d, 0, axis).reshape((old_shape[axis], -1)), 0, 1  # type:ignore
+        )
+        std_scaler.partial_fit(dlist)
+        mm_scaler.partial_fit(dlist)
+    print("hey")

--- a/tests/datasetops/test_datasets.py
+++ b/tests/datasetops/test_datasets.py
@@ -1,8 +1,9 @@
+from typing import Sequence
 from datasetops.dataset import (
     Dataset,
     image_resize,
     reshape,
-    custom,
+    _custom,
     allow_unique,
     one_hot,
     categorical,
@@ -23,12 +24,14 @@ from testing_utils import (  # type:ignore
     DUMMY_NUMPY_DATA_SHAPE_3D,
 )
 
+
 def test_generator():
     ds = from_dummy_data()
     gen = ds.generator()
 
     for d in list(ds):
         assert d == next(gen)
+
 
 def test_shuffle():
     seed = 42
@@ -300,7 +303,10 @@ def test_reorder():
         assert llbl == rlbl
 
     # we can even place the same element multiple times
-    ds_re_creative = ds.reorder(0, 1, 1, 0)
+    with pytest.warns(UserWarning):
+        # but discard item-names (gives a warning)
+        ds_re_creative = ds.reorder(0, 1, 1, 0)
+
     for (ldata, llbl), (rdata1, rlbl1, rlbl2, rdata2) in zip(
         list(ds), list(ds_re_creative)
     ):
@@ -628,7 +634,8 @@ def test_reshape():
         assert np.array_equal(old_data, new_data)
 
     # doing nothing also works
-    ds_dummy = ds.reshape(None, None)
+    with pytest.warns(UserWarning):
+        ds_dummy = ds.reshape(None, None)
     items_dummy = [x for x in ds_dummy]
     for (old_data, _), (new_data, _) in zip(items, items_dummy):
         assert np.array_equal(old_data, new_data)
@@ -640,7 +647,7 @@ def test_reshape():
         # string has no shape
         ds_str.reshape((1, 2))
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         # No input
         ds.reshape()
 
@@ -648,7 +655,7 @@ def test_reshape():
         # bad input
         ds.reshape("whazzagh")
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         # Too many inputs
         ds.reshape(None, None, None)
 
@@ -737,7 +744,7 @@ def test_image_resize():
         assert data.mode == "L"  # grayscale int
 
     # also if they are floats
-    ds_resized_float = ds.transform([custom(np.float32)]).image_resize(NEW_SIZE)
+    ds_resized_float = ds.transform([_custom(np.float32)]).image_resize(NEW_SIZE)
     for tpl in ds_resized_float:
         data = tpl[0]
         assert data.size == NEW_SIZE
@@ -757,7 +764,7 @@ def test_image_resize():
         assert data.size == DUMMY_NUMPY_DATA_SHAPE_2D
 
     # Test error scenarios
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         ds.image_resize()  # No args
 
     with pytest.raises(ValueError):
@@ -824,3 +831,45 @@ def test_to_pytorch():
     # labels equal
     assert torch.all(torch.eq(elem[1][0], torch.Tensor(ds[0][1])))  # type:ignore
     assert torch.all(torch.eq(elem[1][1], torch.Tensor(ds[1][1])))  # type:ignore
+
+
+def test_stats():
+    from sklearn.preprocessing import StandardScaler, MinMaxScaler
+
+    # numpy data
+    ds_np = from_dummy_numpy_data().reshape(DUMMY_NUMPY_DATA_SHAPE_3D)
+
+    std_scaler = StandardScaler()
+    mm_scaler = MinMaxScaler()
+
+    axis = 2
+
+    def _make_scaler_reshapes(data_shape: Sequence[int], axis: int = 0):
+
+        ishape = list(data_shape)
+        ishape[0], ishape[axis] = ishape[axis], ishape[0]
+
+        def reshape_to_scale(d):
+            return np.swapaxes(  # type:ignore
+                np.swapaxes(d, 0, axis).reshape((data_shape[axis], -1)),  # type:ignore
+                0,
+                1,
+            )
+
+        def reshape_from_scale(d):
+            return np.swapaxes(  # type:ignore
+                np.swapaxes(d, 0, 1).reshape(ishape), 0, axis  # type:ignore
+            )
+
+        return reshape_to_scale, reshape_from_scale
+
+    reshape_to_scale, reshape_from_scale = _make_scaler_reshapes(ds_np[0][0].shape, 2)
+
+    for d, l in ds_np:
+        old_shape = d.shape
+        # stats are accumulated along 2nd axis in sklearn preprocessing: reshape accordingly
+        dlist = np.swapaxes(  # type:ignore
+            np.swapaxes(d, 0, axis).reshape((old_shape[axis], -1)), 0, 1  # type:ignore
+        )
+        std_scaler.partial_fit(dlist)
+        mm_scaler.partial_fit(dlist)

--- a/tests/datasetops/test_scaler.py
+++ b/tests/datasetops/test_scaler.py
@@ -1,5 +1,24 @@
-from datasetops.scaler import Scaler, ScalingInfo, _make_scaler_reshapes
+from datasetops.scaler import (
+    ElemStats,
+    _make_scaler_reshapes,
+    fit,
+)
+from datasetops.dataset import center, standardize, minmax, maxabs  # , normalize
 import numpy as np
+from testing_utils import (  # type:ignore
+    multi_shape_dataset,
+)
+import pytest
+
+
+def equal(list_a, list_b) -> bool:
+    return all(
+        [
+            np.array_equal(elem_a, elem_b)
+            for item_a, item_b in zip(list_a, list_b)
+            for elem_a, elem_b in zip(item_a, item_b)
+        ]
+    )
 
 
 def test_scaler_reshapes():
@@ -11,157 +30,228 @@ def test_scaler_reshapes():
         assert len(forward(d).shape) == 2  # type:ignore
         assert np.array_equal(d, backward(forward(d)))
 
+    d = 42
+    forward, backward = _make_scaler_reshapes()
+    assert len(forward(d).shape) == 2  # type:ignore
+    assert d == backward(forward(d))
 
-def test_minmax():
+
+def test_fit():
     SHAPE_1D = (2,)
     SHAPE_3D = (5, 4, 3)
-    orig_data = [
-        # (string, 1D, 3D, scalar, scalar)
-        ("1", np.ones(SHAPE_1D), np.ones(SHAPE_3D), 1, 10),
-        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 20),
-        ("3", 3 * np.ones(SHAPE_1D), 3 * np.ones(SHAPE_3D), 3, 30),
-    ]
+    data0 = [0, 1, 2]
+    data1 = [0 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_1D)]
+    data2 = [0 * np.ones(SHAPE_3D), 1 * np.ones(SHAPE_3D), 2 * np.ones(SHAPE_3D)]
 
-    scaler = Scaler(
-        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
-    )  # omit last items
+    stat0 = fit(data0)
+    stat1 = fit(data1, SHAPE_1D, axis=0)
+    stat2 = fit(data2, SHAPE_3D, axis=-1)
 
-    for d in orig_data:
-        scaler.fit(d)
+    assert np.array_equal(stat0.mean, np.array([1]))  # type: ignore
+    assert np.array_equal(stat0.std, np.array([0.816496580927726]))  # type: ignore
+    assert np.array_equal(stat0.min, np.array([0]))  # type: ignore
+    assert np.array_equal(stat0.max, np.array([2]))  # type: ignore
+    assert stat0.axis == 0
 
-    # default range (0,1)
-    scale_01 = scaler.minmax()  # default range
-    result_01 = [scale_01(d) for d in orig_data]
-    expected_01 = [
-        ("1", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 10),
-        ("2", 0.5 * np.ones(SHAPE_1D), 0.5 * np.ones(SHAPE_3D), 0.5, 20),
-        ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
-    ]
-    for r, e, o in zip(result_01, expected_01, orig_data):
-        assert r[0] == e[0] == o[0]
-        assert np.array_equal(r[1], e[1])
-        assert np.array_equal(r[2], e[2])
-        assert not np.array_equal(r[1], o[1])
-        assert not np.array_equal(r[2], o[2])
-        assert r[3] == e[3] != o[3]
-        assert r[4] == e[4] == o[4]
+    assert np.array_equal(stat1.mean, np.array([1, 1]))  # type: ignore
+    assert np.array_equal(stat1.std, np.array([0.816496580927726, 0.816496580927726]))  # type: ignore
+    assert np.array_equal(stat1.min, np.array([0, 0]))  # type: ignore
+    assert np.array_equal(stat1.max, np.array([2, 2]))  # type: ignore
+    assert stat1.axis == 0
 
-    # custom range (-2,-1)
-    scale_m21 = scaler.minmax(feature_range=(-2, -1))
-    result_m21 = [scale_m21(d) for d in orig_data]
-    expected_m21 = [
-        ("1", -2 * np.ones(SHAPE_1D), -2 * np.ones(SHAPE_3D), -2, 10),
-        ("2", -1.5 * np.ones(SHAPE_1D), -1.5 * np.ones(SHAPE_3D), -1.5, 20),
-        ("3", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 30),
-    ]
-    for r, e, o in zip(result_m21, expected_m21, orig_data):
-        assert r[0] == e[0] == o[0]
-        assert np.array_equal(r[1], e[1])
-        assert np.array_equal(r[2], e[2])
-        assert not np.array_equal(r[1], o[1])
-        assert not np.array_equal(r[2], o[2])
-        assert r[3] == e[3] != o[3]
-        assert r[4] == e[4] == o[4]
+    assert np.array_equal(stat2.mean, np.array([1, 1, 1]))  # type: ignore
+    assert np.array_equal(stat2.std, np.array([0.816496580927726, 0.816496580927726, 0.816496580927726]))  # type: ignore
+    assert np.array_equal(stat2.min, np.array([0, 0, 0]))  # type: ignore
+    assert np.array_equal(stat2.max, np.array([2, 2, 2]))  # type: ignore
+    assert stat2.axis == -1
 
 
-def test_standardize():
-    SHAPE_1D = (2,)
-    SHAPE_3D = (5, 4, 3)
-    orig_data = [
-        # (string, 1D, 3D, scalar, scalar)
-        ("1", np.ones(SHAPE_1D), np.ones(SHAPE_3D), 1, 10),
-        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 20),
-        ("3", 3 * np.ones(SHAPE_1D), 3 * np.ones(SHAPE_3D), 3, 30),
-    ]
+def test_item_stats():
+    # (string, 1D, 3D, scalar)
+    ds = multi_shape_dataset()
 
-    scaler = Scaler(
-        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
-    )  # omit last items
+    stat1d_0 = ds.item_stats(1, axis=None)
+    stat1d_1 = ds.item_stats(1, axis=0)
+    assert (
+        stat1d_0
+        == stat1d_1
+        == ElemStats(
+            mean=np.array([1, 1]),
+            std=np.array([0.816496580927726, 0.816496580927726]),
+            min=np.array([0, 0]),
+            max=np.array([2, 2]),
+        )
+    )
 
-    for d in orig_data:
-        scaler.fit(d)
+    stat3d_0 = ds.item_stats(2, axis=0)
+    stat3d_1 = ds.item_stats(2, axis=-1)
+    stat3d_2 = ds.item_stats(2, axis=2)
+    assert stat3d_0 != stat3d_1
+    assert stat3d_1 == ElemStats(
+        mean=np.array([1, 1, 1]),
+        std=np.array([0.816496580927726, 0.816496580927726, 0.816496580927726]),
+        min=np.array([0, 0, 0]),
+        max=np.array([2, 2, 2]),
+        axis=-1,
+    )
+    assert stat3d_2 == ElemStats(
+        mean=np.array([1, 1, 1]),
+        std=np.array([0.816496580927726, 0.816496580927726, 0.816496580927726]),
+        min=np.array([0, 0, 0]),
+        max=np.array([2, 2, 2]),
+        axis=2,
+    )
 
-    scale_std = scaler.standardize()
-    result = [scale_std(d) for d in orig_data]
-    v = 1.224744871391589  # np.std([-1.224744871391589, 0, -1.224744871391589]) = 1
-    expected = [
-        ("1", -v * np.ones(SHAPE_1D), -v * np.ones(SHAPE_3D), -v, 10),
-        ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
-        ("3", v * np.ones(SHAPE_1D), v * np.ones(SHAPE_3D), v, 30),
-    ]
-    for r, e, o in zip(result, expected, orig_data):
-        assert r[0] == e[0] == o[0]
-        assert np.array_equal(r[1], e[1])
-        assert np.array_equal(r[2], e[2])
-        assert not np.array_equal(r[1], o[1])
-        assert not np.array_equal(r[2], o[2])
-        assert r[3] == e[3] != o[3]
-        assert r[4] == e[4] == o[4]
+    stats_scalar_1 = ds.item_stats(3)
+    stats_scalar_2 = ds.item_stats(3, axis=0)
+    assert (
+        stats_scalar_1
+        == stats_scalar_2
+        == ElemStats(
+            mean=np.array([1]),
+            std=np.array([0.816496580927726]),
+            min=np.array([0]),
+            max=np.array([2]),
+        )
+    )
+
+    with pytest.raises(TypeError):
+        ds.item_stats(0)  # string not supported
 
 
 def test_center():
     SHAPE_1D = (2,)
     SHAPE_3D = (5, 4, 3)
-    orig_data = [
-        # (string, 1D, 3D, scalar, scalar)
-        ("1", np.ones(SHAPE_1D), np.ones(SHAPE_3D), 1, 10),
-        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 20),
-        ("3", 3 * np.ones(SHAPE_1D), 3 * np.ones(SHAPE_3D), 3, 30),
-    ]
+    ds = multi_shape_dataset(SHAPE_1D, SHAPE_3D).named("str", "d1", "d3", "scalar")
 
-    scaler = Scaler(
-        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
-    )  # omit last items
+    ds1 = ds.transform(d1=center())
+    assert equal(
+        list(ds1),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", -1 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0),
+            ("1", 0 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1),
+            ("2", 1 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2),
+        ],
+    )
+    ds1_1 = ds.center("d1")  # centering again does nothing
+    assert equal(list(ds1), list(ds1_1))
 
-    for d in orig_data:
-        scaler.fit(d)
+    ds2 = ds1.center("d3", axis=-1)
+    assert equal(
+        list(ds2),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), 0),
+            ("1", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 1),
+            ("2", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 2),
+        ],
+    )
 
-    scale_center = scaler.center()
-    result = [scale_center(d) for d in orig_data]
-    expected = [
-        ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
-        ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
-        ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
-    ]
-    for r, e, o in zip(result, expected, orig_data):
-        assert r[0] == e[0] == o[0]
-        assert np.array_equal(r[1], e[1])
-        assert np.array_equal(r[2], e[2])
-        assert not np.array_equal(r[1], o[1])
-        assert not np.array_equal(r[2], o[2])
-        assert r[3] == e[3] != o[3]
-        assert r[4] == e[4] == o[4]
+    # multiple with same axis
+    ds1s = ds.center(["d1", "scalar"], axis=0)
+    ds1s_alt = ds.center([1, 3], axis=0)  # index syntax
+    assert equal(list(ds1s), list(ds1s_alt))
+    assert equal(
+        list(ds1s),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", -1 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), -1),
+            ("1", 0 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 0),
+            ("2", 1 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 1),
+        ],
+    )
+
+    # all at once (also testing scalar)
+    ds3 = ds.transform([None, center(), center(axis=-1), center()])
+    ds3_alt = ds.transform(d1=center(), d3=center(axis=-1), scalar=center())
+    assert equal(list(ds3), list(ds3_alt))
+    assert equal(
+        list(ds3),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1),
+            ("1", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0),
+            ("2", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1),
+        ],
+    )
+
+
+def test_standardize():
+    # we've tested the api versions in the center above - just check basic functionality
+    SHAPE_1D = (2,)
+    SHAPE_3D = (5, 4, 3)
+    ds = multi_shape_dataset(SHAPE_1D, SHAPE_3D).named("str", "d1", "d3", "scalar")
+
+    ds_std = ds.transform(d1=standardize(), d3=standardize(axis=-1)).standardize(
+        "scalar"
+    )
+    s = 1.224744871391589
+    assert equal(
+        list(ds_std),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", -s * np.ones(SHAPE_1D), -s * np.ones(SHAPE_3D), -s),
+            ("1", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0),
+            ("2", s * np.ones(SHAPE_1D), s * np.ones(SHAPE_3D), s),
+        ],
+    )
+
+
+# def test_normalize():
+#     # we've tested the api versions in the center above - just check basic functionality
+#     SHAPE_1D = (2,)
+#     SHAPE_3D = (5, 4, 3)
+#     ds = multi_shape_dataset(SHAPE_1D, SHAPE_3D).named("str", "d1", "d3", "scalar")
+
+#     ds_norm = ds.transform(d1=normalize(), d3=normalize(axis=-1, norm="l1")).normalize(
+#         "scalar"
+#     )
+#     v1, v2 = 0.7071067811865475, 0.5773502691896258
+#     assert equal(
+#         list(ds_norm),
+#         [
+#             # (string, 1D, 3D, scalar)
+#             ("0", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0),
+#             ("1", v1 * np.ones(SHAPE_1D), v2 * np.ones(SHAPE_3D), 1),
+#             ("2", v1 * np.ones(SHAPE_1D), v2 * np.ones(SHAPE_3D), 1),
+#         ],
+#     )
+
+
+def test_minmax():
+    # we've tested the api versions in the center above - just check basic functionality
+    SHAPE_1D = (2,)
+    SHAPE_3D = (5, 4, 3)
+    ds = multi_shape_dataset(SHAPE_1D, SHAPE_3D).named("str", "d1", "d3", "scalar")
+
+    ds_mm = ds.transform(d1=minmax(), d3=minmax(axis=-1)).minmax(
+        "scalar", feature_range=(-2, 2)
+    )
+    assert equal(
+        list(ds_mm),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", 0.0 * np.ones(SHAPE_1D), 0.0 * np.ones(SHAPE_3D), -2),
+            ("1", 0.5 * np.ones(SHAPE_1D), 0.5 * np.ones(SHAPE_3D), 0),
+            ("2", 1.0 * np.ones(SHAPE_1D), 1.0 * np.ones(SHAPE_3D), 2),
+        ],
+    )
 
 
 def test_maxabs():
+    # we've tested the api versions in the center above - just check basic functionality
     SHAPE_1D = (2,)
     SHAPE_3D = (5, 4, 3)
-    orig_data = [
-        # (string, 1D, 3D, scalar, scalar)
-        ("1", -4 * np.ones(SHAPE_1D), -4 * np.ones(SHAPE_3D), -4, 10),
-        ("2", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 20),
-        ("3", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 30),
-    ]
+    ds = multi_shape_dataset(SHAPE_1D, SHAPE_3D).named("str", "d1", "d3", "scalar")
 
-    scaler = Scaler(
-        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
-    )  # omit last items
-
-    for d in orig_data:
-        scaler.fit(d)
-
-    scale_maxabs = scaler.maxabs()
-    result = [scale_maxabs(d) for d in orig_data]
-    expected = [
-        ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
-        ("2", 0.25 * np.ones(SHAPE_1D), 0.25 * np.ones(SHAPE_3D), 0.25, 20),
-        ("3", 0.5 * np.ones(SHAPE_1D), 0.5 * np.ones(SHAPE_3D), 0.5, 30),
-    ]
-    for r, e, o in zip(result, expected, orig_data):
-        assert r[0] == e[0] == o[0]
-        assert np.array_equal(r[1], e[1])
-        assert np.array_equal(r[2], e[2])
-        assert not np.array_equal(r[1], o[1])
-        assert not np.array_equal(r[2], o[2])
-        assert r[3] == e[3] != o[3]
-        assert r[4] == e[4] == o[4]
+    ds_ma = ds.transform(d1=maxabs(), d3=maxabs(axis=-1)).maxabs("scalar")
+    assert equal(
+        list(ds_ma),
+        [
+            # (string, 1D, 3D, scalar)
+            ("0", 0.0 * np.ones(SHAPE_1D), 0.0 * np.ones(SHAPE_3D), 0.0),
+            ("1", 0.5 * np.ones(SHAPE_1D), 0.5 * np.ones(SHAPE_3D), 0.5),
+            ("2", 1.0 * np.ones(SHAPE_1D), 1.0 * np.ones(SHAPE_3D), 1.0),
+        ],
+    )

--- a/tests/datasetops/test_scaler.py
+++ b/tests/datasetops/test_scaler.py
@@ -81,7 +81,7 @@ def test_standardize():
     for d in orig_data:
         scaler.fit(d)
 
-    scale_std = scaler.standardize() 
+    scale_std = scaler.standardize()
     result = [scale_std(d) for d in orig_data]
     v = 1.224744871391589  # np.std([-1.224744871391589, 0, -1.224744871391589]) = 1
     expected = [
@@ -116,12 +116,46 @@ def test_center():
     for d in orig_data:
         scaler.fit(d)
 
-    scale_center = scaler.center() 
+    scale_center = scaler.center()
     result = [scale_center(d) for d in orig_data]
     expected = [
         ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
         ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
         ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
+    ]
+    for r, e, o in zip(result, expected, orig_data):
+        assert r[0] == e[0] == o[0]
+        assert np.array_equal(r[1], e[1])
+        assert np.array_equal(r[2], e[2])
+        assert not np.array_equal(r[1], o[1])
+        assert not np.array_equal(r[2], o[2])
+        assert r[3] == e[3] != o[3]
+        assert r[4] == e[4] == o[4]
+
+
+def test_maxabs():
+    SHAPE_1D = (2,)
+    SHAPE_3D = (5, 4, 3)
+    orig_data = [
+        # (string, 1D, 3D, scalar, scalar)
+        ("1", -4 * np.ones(SHAPE_1D), -4 * np.ones(SHAPE_3D), -4, 10),
+        ("2", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 20),
+        ("3", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 30),
+    ]
+
+    scaler = Scaler(
+        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
+    )  # omit last items
+
+    for d in orig_data:
+        scaler.fit(d)
+
+    scale_maxabs = scaler.maxabs()
+    result = [scale_maxabs(d) for d in orig_data]
+    expected = [
+        ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
+        ("2", 0.25 * np.ones(SHAPE_1D), 0.25 * np.ones(SHAPE_3D), 0.25, 20),
+        ("3", 0.5 * np.ones(SHAPE_1D), 0.5 * np.ones(SHAPE_3D), 0.5, 30),
     ]
     for r, e, o in zip(result, expected, orig_data):
         assert r[0] == e[0] == o[0]

--- a/tests/datasetops/test_scaler.py
+++ b/tests/datasetops/test_scaler.py
@@ -1,0 +1,64 @@
+from datasetops.scaler import Scaler, ScalingInfo, _make_scaler_reshapes
+import numpy as np
+
+
+def test_scaler_reshapes():
+    shape = [3, 4, 5]
+    d = np.arange(np.prod(shape)).reshape(shape)  # type:ignore
+
+    for axis in range(len(shape)):
+        forward, backward = _make_scaler_reshapes(shape, axis)
+        assert len(forward(d).shape) == 2  # type:ignore
+        assert np.array_equal(d, backward(forward(d)))
+
+
+def test_minmax():
+    SHAPE_1D = (2,)
+    SHAPE_3D = (5, 4, 3)
+    orig_data = [
+        # (string, 1D, 3D, scalar, scalar)
+        ("1", np.ones(SHAPE_1D), np.ones(SHAPE_3D), 1, 10),
+        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 20),
+        ("3", 3 * np.ones(SHAPE_1D), 3 * np.ones(SHAPE_3D), 3, 30),
+    ]
+
+    scaler = Scaler(
+        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
+    )  # omit last items
+
+    for d in orig_data:
+        scaler.fit(d)
+
+    # default range (0,1)
+    scale_01 = scaler.minmax()  # default range
+    result_01 = [scale_01(d) for d in orig_data]
+    expected_01 = [
+        ("1", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 10),
+        ("2", 0.5 * np.ones(SHAPE_1D), 0.5 * np.ones(SHAPE_3D), 0.5, 20),
+        ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
+    ]
+    for r, e, o in zip(result_01, expected_01, orig_data):
+        assert r[0] == e[0] == o[0]
+        assert np.array_equal(r[1], e[1])
+        assert np.array_equal(r[2], e[2])
+        assert not np.array_equal(r[1], o[1])
+        assert not np.array_equal(r[2], o[2])
+        assert r[3] == e[3] != o[3]
+        assert r[4] == e[4] == o[4]
+
+    # custom range (-1,1)
+    scale_pm1 = scaler.minmax(feature_range=(-1, 1))
+    result_pm1 = [scale_pm1(d) for d in orig_data]
+    expected_pm1 = [
+        ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
+        ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
+        ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
+    ]
+    for r, e, o in zip(result_pm1, expected_pm1, orig_data):
+        assert r[0] == e[0] == o[0]
+        assert np.array_equal(r[1], e[1])
+        assert np.array_equal(r[2], e[2])
+        assert not np.array_equal(r[1], o[1])
+        assert not np.array_equal(r[2], o[2])
+        assert r[3] == e[3] != o[3]
+        assert r[4] == e[4] == o[4]

--- a/tests/datasetops/test_scaler.py
+++ b/tests/datasetops/test_scaler.py
@@ -81,14 +81,47 @@ def test_standardize():
     for d in orig_data:
         scaler.fit(d)
 
-    # default range (0,1)
-    scale_std = scaler.standardize()  # default range
+    scale_std = scaler.standardize() 
     result = [scale_std(d) for d in orig_data]
     v = 1.224744871391589  # np.std([-1.224744871391589, 0, -1.224744871391589]) = 1
     expected = [
         ("1", -v * np.ones(SHAPE_1D), -v * np.ones(SHAPE_3D), -v, 10),
         ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
         ("3", v * np.ones(SHAPE_1D), v * np.ones(SHAPE_3D), v, 30),
+    ]
+    for r, e, o in zip(result, expected, orig_data):
+        assert r[0] == e[0] == o[0]
+        assert np.array_equal(r[1], e[1])
+        assert np.array_equal(r[2], e[2])
+        assert not np.array_equal(r[1], o[1])
+        assert not np.array_equal(r[2], o[2])
+        assert r[3] == e[3] != o[3]
+        assert r[4] == e[4] == o[4]
+
+
+def test_center():
+    SHAPE_1D = (2,)
+    SHAPE_3D = (5, 4, 3)
+    orig_data = [
+        # (string, 1D, 3D, scalar, scalar)
+        ("1", np.ones(SHAPE_1D), np.ones(SHAPE_3D), 1, 10),
+        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 20),
+        ("3", 3 * np.ones(SHAPE_1D), 3 * np.ones(SHAPE_3D), 3, 30),
+    ]
+
+    scaler = Scaler(
+        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
+    )  # omit last items
+
+    for d in orig_data:
+        scaler.fit(d)
+
+    scale_center = scaler.center() 
+    result = [scale_center(d) for d in orig_data]
+    expected = [
+        ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
+        ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
+        ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
     ]
     for r, e, o in zip(result, expected, orig_data):
         assert r[0] == e[0] == o[0]

--- a/tests/datasetops/test_scaler.py
+++ b/tests/datasetops/test_scaler.py
@@ -46,15 +46,51 @@ def test_minmax():
         assert r[3] == e[3] != o[3]
         assert r[4] == e[4] == o[4]
 
-    # custom range (-1,1)
-    scale_pm1 = scaler.minmax(feature_range=(-1, 1))
-    result_pm1 = [scale_pm1(d) for d in orig_data]
-    expected_pm1 = [
-        ("1", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 10),
-        ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
-        ("3", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1, 30),
+    # custom range (-2,-1)
+    scale_m21 = scaler.minmax(feature_range=(-2, -1))
+    result_m21 = [scale_m21(d) for d in orig_data]
+    expected_m21 = [
+        ("1", -2 * np.ones(SHAPE_1D), -2 * np.ones(SHAPE_3D), -2, 10),
+        ("2", -1.5 * np.ones(SHAPE_1D), -1.5 * np.ones(SHAPE_3D), -1.5, 20),
+        ("3", -1 * np.ones(SHAPE_1D), -1 * np.ones(SHAPE_3D), -1, 30),
     ]
-    for r, e, o in zip(result_pm1, expected_pm1, orig_data):
+    for r, e, o in zip(result_m21, expected_m21, orig_data):
+        assert r[0] == e[0] == o[0]
+        assert np.array_equal(r[1], e[1])
+        assert np.array_equal(r[2], e[2])
+        assert not np.array_equal(r[1], o[1])
+        assert not np.array_equal(r[2], o[2])
+        assert r[3] == e[3] != o[3]
+        assert r[4] == e[4] == o[4]
+
+
+def test_standardize():
+    SHAPE_1D = (2,)
+    SHAPE_3D = (5, 4, 3)
+    orig_data = [
+        # (string, 1D, 3D, scalar, scalar)
+        ("1", np.ones(SHAPE_1D), np.ones(SHAPE_3D), 1, 10),
+        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2, 20),
+        ("3", 3 * np.ones(SHAPE_1D), 3 * np.ones(SHAPE_3D), 3, 30),
+    ]
+
+    scaler = Scaler(
+        [None, ScalingInfo(SHAPE_1D), ScalingInfo(SHAPE_3D, 2), ScalingInfo()]
+    )  # omit last items
+
+    for d in orig_data:
+        scaler.fit(d)
+
+    # default range (0,1)
+    scale_std = scaler.standardize()  # default range
+    result = [scale_std(d) for d in orig_data]
+    v = 1.224744871391589  # np.std([-1.224744871391589, 0, -1.224744871391589]) = 1
+    expected = [
+        ("1", -v * np.ones(SHAPE_1D), -v * np.ones(SHAPE_3D), -v, 10),
+        ("2", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0, 20),
+        ("3", v * np.ones(SHAPE_1D), v * np.ones(SHAPE_3D), v, 30),
+    ]
+    for r, e, o in zip(result, expected, orig_data):
         assert r[0] == e[0] == o[0]
         assert np.array_equal(r[1], e[1])
         assert np.array_equal(r[2], e[2])

--- a/tests/datasetops/testing_utils.py
+++ b/tests/datasetops/testing_utils.py
@@ -61,3 +61,19 @@ def from_dummy_numpy_data() -> Loader:
     ds.extend(a_ids)
     ds.extend(b_ids)
     return ds
+
+
+def multi_shape_dataset(SHAPE_1D=(2,), SHAPE_3D=(5, 4, 3)):
+    data = [
+        # (string, 1D, 3D, scalar)
+        ("0", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0),
+        ("1", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1),
+        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2),
+    ]
+
+    def get_data(idx):
+        return data[idx]
+
+    ds = Loader(get_data)
+    ds.extend(list(range(len(data))))
+    return ds

--- a/tests/datasetops/testing_utils.py
+++ b/tests/datasetops/testing_utils.py
@@ -58,3 +58,19 @@ def from_dummy_numpy_data() -> Loader:
     ds.extend(a_ids)
     ds.extend(b_ids)
     return ds
+
+
+def multi_shape_dataset(SHAPE_1D=(2,), SHAPE_3D=(5, 4, 3)):
+    data = [
+        # (string, 1D, 3D, scalar)
+        ("0", 0 * np.ones(SHAPE_1D), 0 * np.ones(SHAPE_3D), 0),
+        ("1", 1 * np.ones(SHAPE_1D), 1 * np.ones(SHAPE_3D), 1),
+        ("2", 2 * np.ones(SHAPE_1D), 2 * np.ones(SHAPE_3D), 2),
+    ]
+
+    def get_data(idx):
+        return data[idx]
+
+    ds = Loader(get_data)
+    ds.extend(list(range(len(data))))
+    return ds


### PR DESCRIPTION
Add `item_stats(key)` for computing min, max, mean, std for an element.
Add scalers:
- `standardize`
- `center`
- `minmax`
- `maxabs`

Also implemented `normalize`, but commented it out for now. There is an issue, that people understand the term 'normalize' differently. Some think of rescaling into a range (this is minmax scaling), some think of scaling to unit variance (this is standardizing). In the scikit-learn terminology, normalize mean to scale each feature, such that has a norm of 1. This is what was implemented. However, it is used very seldom, so I think we should not include it, because most people with probably confuse it with standardize or minmax.

There have been some implementational changes to the underlying _optional_argument_indexed_transform and the functions that use it in order to accommodate passing multiple args (previously, we could only pass one).

Also renamed `custom` to `_custom` (made it private), c.f. https://github.com/LukasHedegaard/datasetops/issues/29